### PR TITLE
grevm(bench): use jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rayon = "1.10.0"
 revme = "0.10.3"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
+tikv-jemallocator = "0.5.0"
 
 [lints]
 rust.missing_debug_implementations = "warn"

--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -21,6 +21,9 @@ pub mod erc20;
 
 const GIGA_GAS: u64 = 1_000_000_000;
 
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
     let mut env = Env::default();
     env.cfg.chain_id = NamedChain::Mainnet.into();


### PR DESCRIPTION
Before opt.
```
Independent Raw Transfers/Grevm Parallel
                        time:   [98.506 ms 98.753 ms 99.054 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [140.20 ms 140.38 ms 140.56 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [128.41 ms 133.10 ms 136.94 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [155.43 ms 156.02 ms 156.59 ms]
Independent ERC20/Grevm Parallel
                        time:   [156.48 ms 164.46 ms 168.22 ms]
Independent ERC20/Grevm Sequential
                        time:   [375.84 ms 378.80 ms 382.84 ms]
Dependent ERC20/Grevm Parallel
                        time:   [204.78 ms 208.37 ms 212.92 ms]
Dependent ERC20/Grevm Sequential
                        time:   [402.04 ms 405.76 ms 412.05 ms]
```
After opt.
```
Independent Raw Transfers/Grevm Parallel
                        time:   [73.239 ms 73.784 ms 74.462 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [115.76 ms 116.95 ms 118.81 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [97.909 ms 100.09 ms 102.13 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [131.94 ms 133.99 ms 135.92 ms]
Independent ERC20/Grevm Parallel
                        time:   [108.04 ms 109.79 ms 111.26 ms]
Independent ERC20/Grevm Sequential
                        time:   [328.73 ms 329.85 ms 330.96 ms]
Dependent ERC20/Grevm Parallel
                        time:   [142.84 ms 144.50 ms 146.22 ms]
Dependent ERC20/Grevm Sequential
                        time:   [360.36 ms 365.79 ms 372.27 ms]
```