### PR TITLE
grevm(opt): optimize cache state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
-use revm::primitives::{Address, EVMError, EVMResultGeneric, ExecutionResult, U256};
-use revm::TransitionAccount;
+use revm::primitives::{Address, EVMError, EVMResultGeneric, EvmState, ExecutionResult, U256};
 use std::cmp::min;
 use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -13,13 +12,14 @@ mod storage;
 mod tx_dependency;
 
 lazy_static! {
-    static ref CPU_CORES: usize = thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+    static ref CPU_CORES: usize =
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
 }
 
 lazy_static! {
     static ref GREVM_RUNTIME: Runtime = Builder::new_multi_thread()
         // .worker_threads(1) // for debug
-        .worker_threads(thread::available_parallelism().map(|n| n.get() * 2).unwrap_or(8))
+        .worker_threads(std::thread::available_parallelism().map(|n| n.get() * 2).unwrap_or(8))
         .thread_name("grevm-tokio-runtime")
         .enable_all()
         .build()
@@ -75,7 +75,7 @@ pub struct ResultAndTransition {
     /// Status of execution
     pub result: Option<ExecutionResult>,
     /// State that got updated
-    pub transition: Vec<(Address, TransitionAccount)>,
+    pub transition: EvmState,
     /// Rewards to miner
     pub rewards: u128,
 }

--- a/tests/common/execute.rs
+++ b/tests/common/execute.rs
@@ -17,8 +17,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 fn compare_bundle_state(left: &BundleState, right: &BundleState) {
-    let left = left.clone();
-    let right = right.clone();
     assert!(
         left.contracts.keys().all(|k| right.contracts.contains_key(k)),
         "Left contracts: {:?}, Right contracts: {:?}",
@@ -33,22 +31,21 @@ fn compare_bundle_state(left: &BundleState, right: &BundleState) {
         right.contracts.keys()
     );
 
-    let left_state: BTreeMap<Address, BundleAccount> = left.state.into_iter().collect();
-    let right_state: BTreeMap<Address, BundleAccount> = right.state.into_iter().collect();
+    let left_state: BTreeMap<&Address, &BundleAccount> = left.state.iter().collect();
+    let right_state: BTreeMap<&Address, &BundleAccount> = right.state.iter().collect();
     assert_eq!(left_state.len(), right_state.len());
 
     for ((addr1, account1), (addr2, account2)) in
         left_state.into_iter().zip(right_state.into_iter())
     {
         assert_eq!(addr1, addr2);
-        let BundleAccount { info, original_info, storage, status } = account1;
-        assert_eq!(info, account2.info);
-        assert_eq!(original_info, account2.original_info);
-        assert_eq!(status, account2.status);
-        let left_storage: BTreeMap<U256, StorageSlot> = storage.into_iter().collect();
-        let right_storage: BTreeMap<U256, StorageSlot> = account2.storage.into_iter().collect();
+        assert_eq!(account1.info, account2.info, "Address: {:?}", addr1);
+        assert_eq!(account1.original_info, account2.original_info, "Address: {:?}", addr1);
+        assert_eq!(account1.status, account2.status, "Address: {:?}", addr1);
+        let left_storage: BTreeMap<&U256, &StorageSlot> = account1.storage.iter().collect();
+        let right_storage: BTreeMap<&U256, &StorageSlot> = account2.storage.iter().collect();
         for (s1, s2) in left_storage.into_iter().zip(right_storage.into_iter()) {
-            assert_eq!(s1, s2);
+            assert_eq!(s1, s2, "Address: {:?}", addr1);
         }
     }
 }


### PR DESCRIPTION
- Apply evm state changes to state cache without generating transition.
- Directly merge partition state cache to scheduler if there are no conflicts in the entire partition.

Before opt.
```
Independent Raw Transfers/Grevm Parallel
                        time:   [71.706 ms 73.537 ms 77.904 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [115.13 ms 117.05 ms 118.41 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [95.392 ms 96.752 ms 98.168 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [127.72 ms 128.53 ms 129.83 ms]
Independent ERC20/Grevm Parallel
                        time:   [94.768 ms 96.723 ms 99.558 ms]
Independent ERC20/Grevm Sequential
                        time:   [198.46 ms 200.44 ms 202.76 ms]
Dependent ERC20/Grevm Parallel
                        time:   [128.26 ms 133.78 ms 137.61 ms]
Dependent ERC20/Grevm Sequential
                        time:   [220.80 ms 223.12 ms 225.42 ms]
```
After opt.
```
Independent Raw Transfers/Grevm Parallel
                        time:   [65.826 ms 66.189 ms 66.474 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [99.834 ms 100.71 ms 101.30 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [82.873 ms 84.296 ms 85.306 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [108.55 ms 111.08 ms 112.60 ms]
Independent ERC20/Grevm Parallel
                        time:   [81.495 ms 82.734 ms 84.965 ms]
Independent ERC20/Grevm Sequential
                        time:   [186.97 ms 189.85 ms 193.19 ms]
Dependent ERC20/Grevm Parallel
                        time:   [113.41 ms 114.57 ms 116.73 ms]
Dependent ERC20/Grevm Sequential
                        time:   [196.04 ms 196.59 ms 197.16 ms]
```