### PR TITLE
grevm(opt): skip validation if the read/write set are not overflow hints

### DIFF
--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -31,7 +31,7 @@ fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
     let db = Arc::new(db);
 
     let mut group = c.benchmark_group(name);
-    group.bench_function("Sequential", |b| {
+    group.bench_function("Origin Sequential", |b| {
         b.iter(|| {
             common::execute_revm_sequential(
                 black_box(db.clone()),
@@ -51,7 +51,7 @@ fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
                 black_box(db.clone()),
                 black_box(txs.clone()),
             );
-            executor.adaptive_execute()
+            executor.parallel_execute()
         })
     });
     group.bench_function("Grevm Sequential", |b| {
@@ -64,7 +64,7 @@ fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
                 black_box(db.clone()),
                 black_box(txs.clone()),
             );
-            executor.sequential_execute()
+            executor.force_sequential_execute()
         })
     });
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,15 @@ enum LocationAndType {
     Code(Address),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 enum TransactionStatus {
-    Initial,     // tx that has not yet been run once
-    Unconfirmed, // tx that is validated but not the continuous ID
-    Pending,     // tx that is pending to wait other txs ready
-    Conflict,    // tx that is conflicted and need to rerun
-    Finality,    // tx that is validated and is the continuous ID
+    Initial,        // tx that has not yet been run once
+    Executed,       // tx that are executed
+    Unconfirmed,    // tx that is validated but not the continuous ID
+    Pending,        // tx that is pending to wait other txs ready
+    Conflict,       // tx that is conflicted and need to rerun
+    SkipValidation, // tx that can skip validate
+    Finality,       // tx that is validated and is the continuous ID
 }
 
 pub struct PartitionIndex {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,6 +1,9 @@
 use crate::storage::{PartitionDB, SchedulerDB};
-use crate::{GrevmResult, LocationAndType, PartitionId, ResultAndTransition, TxId};
-use revm::primitives::{Address, Env, SpecId, TxEnv, TxKind};
+use crate::{
+    LocationAndType, PartitionId, ResultAndTransition, SharedTxStates, TransactionStatus, TxId,
+    TxState,
+};
+use revm::primitives::{Address, EVMError, Env, ResultAndState, SpecId, TxEnv, TxKind};
 use revm::{DatabaseRef, EvmBuilder};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
@@ -29,29 +32,6 @@ impl<E: Ord> OrderedVectorExt<E> for Vec<E> {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct PreUnconfirmedContext {
-    pub read_set: HashSet<LocationAndType>,
-    pub write_set: HashSet<LocationAndType>,
-    pub execute_state: ResultAndTransition,
-}
-
-/// Record some status from the previous round,
-/// which can accelerate the execution of the current round
-#[derive(Default)]
-pub(crate) struct PreRoundContext {
-    pub pre_unconfirmed_txs: HashMap<TxId, PreUnconfirmedContext>,
-}
-
-impl PreRoundContext {
-    pub(crate) fn take_pre_unconfirmed_ctx(
-        &mut self,
-        txid: &TxId,
-    ) -> Option<PreUnconfirmedContext> {
-        self.pre_unconfirmed_txs.remove(txid)
-    }
-}
-
 pub(crate) struct PartitionExecutor<DB>
 where
     DB: DatabaseRef,
@@ -59,22 +39,16 @@ where
     spec_id: SpecId,
     env: Env,
     coinbase: Address,
-    pub partition_id: PartitionId,
+    partition_id: PartitionId,
+    tx_states: SharedTxStates,
+    txs: Arc<Vec<TxEnv>>,
 
     pub partition_db: PartitionDB<DB>,
-
-    txs: Arc<Vec<TxEnv>>,
     pub assigned_txs: Vec<TxId>,
-    pub read_set: Vec<HashSet<LocationAndType>>,
-    pub write_set: Vec<HashSet<LocationAndType>>,
 
-    pub execute_results: Vec<GrevmResult<DB::Error>>,
+    pub error_txs: HashMap<TxId, EVMError<DB::Error>>,
 
-    pub conflict_txs: Vec<TxId>,
-    pub unconfirmed_txs: Vec<(TxId, usize)>, // TxId and index
     pub tx_dependency: Vec<BTreeSet<TxId>>,
-
-    pub pre_round_ctx: Option<PreRoundContext>,
 
     pub metrics: PartitionMetrics,
 }
@@ -89,6 +63,7 @@ where
         env: Env,
         scheduler_db: Arc<SchedulerDB<DB>>,
         txs: Arc<Vec<TxEnv>>,
+        tx_states: SharedTxStates,
         assigned_txs: Vec<TxId>,
     ) -> Self {
         let coinbase = env.block.coinbase.clone();
@@ -98,35 +73,35 @@ where
             env,
             coinbase,
             partition_id,
-            partition_db,
+            tx_states,
             txs,
+            partition_db,
             assigned_txs,
-            read_set: vec![],
-            write_set: vec![],
-            execute_results: vec![],
-            conflict_txs: vec![],
-            unconfirmed_txs: vec![],
+            error_txs: HashMap::new(),
             tx_dependency: vec![],
-            pre_round_ctx: None,
             metrics: Default::default(),
         }
     }
 
-    pub(crate) fn set_pre_round_ctx(&mut self, pre_round_context: Option<PreRoundContext>) {
-        self.pre_round_ctx = pre_round_context;
-    }
-
     pub(crate) fn execute(&mut self) {
         let start = Instant::now();
+        let mut has_unconfirmed_tx = false;
         let mut update_write_set: HashSet<LocationAndType> = HashSet::new();
         let mut evm = EvmBuilder::default()
             .with_db(&mut self.partition_db)
             .with_spec_id(self.spec_id)
             .with_env(Box::new(self.env.clone()))
             .build();
+
+        #[allow(invalid_reference_casting)]
+        let tx_states =
+            unsafe { &mut *(&(*self.tx_states) as *const Vec<TxState> as *mut Vec<TxState>) };
+
         for txid in &self.assigned_txs {
+            let txid = *txid;
+
             let mut miner_involved = false;
-            if let Some(tx) = self.txs.get(*txid) {
+            if let Some(tx) = self.txs.get(txid) {
                 *evm.tx_mut() = tx.clone();
                 // If the transaction includes the miner’s address,
                 // we need to record the miner’s address in both the write and read sets,
@@ -142,52 +117,64 @@ where
             } else {
                 panic!("Wrong transactions ID");
             }
-            let mut should_rerun = true;
-            if let Some(ctx) = self.pre_round_ctx.as_mut() {
-                if let Some(PreUnconfirmedContext { read_set, write_set, execute_state }) =
-                    ctx.take_pre_unconfirmed_ctx(txid)
-                {
-                    // The unconfirmed transactions from the previous round may not require repeated execution.
-                    // The verification process is as follows:
-                    // 1. create a write set(update_write_set) to store write_set of previous conflict tx
-                    // 2. if an unconfirmed tx rerun, store write_set to update_write_set
-                    // 3. when running an unconfirmed tx, take it's pre-round read_set to join with update_write_set
-                    // 4. if the intersection is None, the unconfirmed tx no need to rerun, otherwise rerun
-                    if read_set.is_disjoint(&update_write_set) {
-                        self.read_set.push(read_set);
-                        self.write_set.push(write_set);
-                        evm.db_mut().temporary_commit_transition(&execute_state.transition);
-                        self.execute_results.push(Ok(execute_state));
-                        should_rerun = false;
-                        self.metrics.reusable_tx_cnt += 1;
-                    }
+            let mut should_execute = true;
+            if tx_states[txid].tx_status == TransactionStatus::Unconfirmed {
+                has_unconfirmed_tx = true;
+                // The unconfirmed transactions from the previous round may not require repeated execution.
+                // The verification process is as follows:
+                // 1. create a write set(update_write_set) to store write_set of previous conflict tx
+                // 2. if an unconfirmed tx rerun, store write_set to update_write_set
+                // 3. when running an unconfirmed tx, take it's pre-round read_set to join with update_write_set
+                // 4. if the intersection is None, the unconfirmed tx no need to rerun, otherwise rerun
+                if tx_states[txid].read_set.is_disjoint(&update_write_set) {
+                    let transition = &tx_states[txid].execute_result.transition;
+                    evm.db_mut().temporary_commit_transition(transition);
+                    should_execute = false;
+                    self.metrics.reusable_tx_cnt += 1;
+                    tx_states[txid].tx_status = TransactionStatus::SkipValidation;
                 }
             }
-            if should_rerun {
+            if should_execute {
                 evm.db_mut().miner_involved = miner_involved;
                 let result = evm.transact();
                 match result {
                     Ok(mut result_and_state) => {
-                        // update read set
-                        self.read_set.push(evm.db_mut().take_read_set());
-                        // update write set
+                        let read_set = evm.db_mut().take_read_set();
                         let (write_set, rewards) =
                             evm.db().generate_write_set(&result_and_state.state);
-                        if self.pre_round_ctx.is_some() {
+                        if has_unconfirmed_tx {
                             update_write_set.extend(write_set.clone().into_iter());
                         }
-                        self.write_set.push(write_set);
+
+                        let mut skip_validation = true;
+                        if !read_set.is_subset(&tx_states[txid].read_set) {
+                            skip_validation = false;
+                        }
+                        if skip_validation && !write_set.is_subset(&tx_states[txid].write_set) {
+                            skip_validation = false;
+                        }
+
+                        let ResultAndState { result, mut state } = result_and_state;
                         if rewards.is_some() {
                             // remove miner's state if we handle rewards separately
-                            result_and_state.state.remove(&self.coinbase);
+                            state.remove(&self.coinbase);
                         }
                         // temporary commit to cache_db, to make use the remaining txs can read the updated data
-                        let transition = evm.db_mut().temporary_commit(result_and_state.state);
-                        self.execute_results.push(Ok(ResultAndTransition {
-                            result: Some(result_and_state.result),
-                            transition,
-                            rewards: rewards.unwrap_or(0),
-                        }));
+                        let transition = evm.db_mut().temporary_commit(state);
+                        tx_states[txid] = TxState {
+                            tx_status: if skip_validation {
+                                TransactionStatus::SkipValidation
+                            } else {
+                                TransactionStatus::Executed
+                            },
+                            read_set,
+                            write_set,
+                            execute_result: ResultAndTransition {
+                                result: Some(result),
+                                transition,
+                                rewards: rewards.unwrap_or(0),
+                            },
+                        };
                     }
                     Err(err) => {
                         // Due to parallel execution, transactions may fail (such as dependent transfers not yet received),
@@ -205,14 +192,18 @@ where
                             read_set.insert(LocationAndType::Basic(to));
                             write_set.insert(LocationAndType::Basic(to));
                         }
-                        self.read_set.push(read_set);
-                        self.write_set.push(write_set);
-                        self.execute_results.push(Err(err));
+
+                        tx_states[txid] = TxState {
+                            tx_status: TransactionStatus::Conflict,
+                            read_set,
+                            write_set,
+                            execute_result: ResultAndTransition::default(),
+                        };
+                        self.error_txs.insert(txid, err);
                     }
                 }
             }
         }
-        assert_eq!(self.assigned_txs.len(), self.execute_results.len());
         self.metrics.execute_time = start.elapsed();
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::LocationAndType;
+use crate::{LocationAndType, LocationSet};
 use revm::db::states::bundle_state::BundleRetention;
 use revm::db::states::CacheAccount;
 use revm::db::{BundleState, PlainAccount};
@@ -260,7 +260,7 @@ pub(crate) struct PartitionDB<DB> {
     /// Does the miner participate in the transaction
     pub miner_involved: bool,
     /// Record the read set of current tx, will be consumed after the execution of each tx
-    tx_read_set: HashSet<LocationAndType>,
+    tx_read_set: LocationSet,
 }
 
 impl<DB> PartitionDB<DB> {
@@ -276,15 +276,12 @@ impl<DB> PartitionDB<DB> {
     }
 
     /// consume the read set after evm.transact() for each tx
-    pub(crate) fn take_read_set(&mut self) -> HashSet<LocationAndType> {
+    pub(crate) fn take_read_set(&mut self) -> LocationSet {
         core::mem::take(&mut self.tx_read_set)
     }
 
     /// Generate the write set after evm.transact() for each tx
-    pub(crate) fn generate_write_set(
-        &self,
-        changes: &EvmState,
-    ) -> (HashSet<LocationAndType>, Option<u128>) {
+    pub(crate) fn generate_write_set(&self, changes: &EvmState) -> (LocationSet, Option<u128>) {
         let mut rewards: Option<u128> = None;
         let mut write_set = HashSet::new();
         for (address, account) in changes {

--- a/tests/common/execute.rs
+++ b/tests/common/execute.rs
@@ -109,7 +109,7 @@ pub fn compare_evm_execute<DB>(
     let db = Arc::new(db);
     let start = Instant::now();
     let sequential = GrevmScheduler::new(SpecId::LATEST, env.clone(), db.clone(), txs.clone());
-    let sequential_result = sequential.sequential_execute();
+    let sequential_result = sequential.force_sequential_execute();
     println!("Grevm sequential execute time: {}ms", start.elapsed().as_millis());
 
     let mut parallel_result = Err(GrevmError::UnreachableError(String::from("Init")));
@@ -117,11 +117,8 @@ pub fn compare_evm_execute<DB>(
         let start = Instant::now();
         let mut parallel =
             GrevmScheduler::new(SpecId::LATEST, env.clone(), db.clone(), txs.clone());
-        if !with_hints {
-            parallel.clean_dependency();
-        }
-        parallel.set_num_partitions(23); // set determined partitions
-        parallel_result = parallel.evm_execute(Some(false));
+        // set determined partitions
+        parallel_result = parallel.force_parallel_execute(with_hints, Some(23));
         println!("Grevm parallel execute time: {}ms", start.elapsed().as_millis());
 
         let snapshot = recorder.snapshotter().snapshot();

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -53,6 +53,7 @@ fn erc20_gigagas() {
             ("grevm.sequential_execute_calls", DebugValue::Counter(0)),
             ("grevm.parallel_tx_cnt", DebugValue::Counter(block_size as u64)),
             ("grevm.conflict_tx_cnt", DebugValue::Counter(0)),
+            ("grevm.skip_validation_cnt", DebugValue::Counter(block_size as u64)),
         ]
         .into_iter()
         .collect(),
@@ -127,6 +128,7 @@ fn erc20_hints_test() {
             ("grevm.conflict_tx_cnt", DebugValue::Counter(0)),
             ("grevm.unconfirmed_tx_cnt", DebugValue::Counter(0)),
             ("grevm.reusable_tx_cnt", DebugValue::Counter(0)),
+            ("grevm.skip_validation_cnt", DebugValue::Counter(3)),
             // important metrics!!! (tx0, tx1) are independent with (tx2)
             // so there are two partitions
             ("grevm.concurrent_partition_num", DebugValue::Gauge(2.0.into())),

--- a/tests/native_transfers.rs
+++ b/tests/native_transfers.rs
@@ -42,6 +42,7 @@ fn native_gigagas() {
             ("grevm.conflict_tx_cnt", DebugValue::Counter(0)),
             ("grevm.unconfirmed_tx_cnt", DebugValue::Counter(0)),
             ("grevm.reusable_tx_cnt", DebugValue::Counter(0)),
+            ("grevm.skip_validation_cnt", DebugValue::Counter(block_size as u64)),
             ("grevm.partition_num_tx_diff", DebugValue::Gauge(1.0.into())),
         ]
         .into_iter()
@@ -79,6 +80,7 @@ fn native_transfers_independent() {
             ("grevm.conflict_tx_cnt", DebugValue::Counter(0)),
             ("grevm.unconfirmed_tx_cnt", DebugValue::Counter(0)),
             ("grevm.reusable_tx_cnt", DebugValue::Counter(0)),
+            ("grevm.skip_validation_cnt", DebugValue::Counter(block_size as u64)),
             ("grevm.partition_num_tx_diff", DebugValue::Gauge(1.0.into())),
         ]
         .into_iter()


### PR DESCRIPTION
## Skip validation if the read/write set are not overflow hints
**Before opt.**
```
Independent Raw Transfers/Origin Sequential
                        time:   [101.89 ms 102.01 ms 102.18 ms]
Independent Raw Transfers/Grevm Parallel
                        time:   [68.397 ms 68.560 ms 68.724 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [117.47 ms 122.22 ms 127.74 ms]

Dependent Raw Transfers/Origin Sequential
                        time:   [118.49 ms 119.14 ms 119.92 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [90.620 ms 91.590 ms 92.760 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [127.41 ms 127.97 ms 128.67 ms]

Independent ERC20/Origin Sequential
                        time:   [184.84 ms 185.39 ms 186.06 ms]
Independent ERC20/Grevm Parallel
                        time:   [94.724 ms 95.214 ms 95.812 ms]
Independent ERC20/Grevm Sequential
                        time:   [198.12 ms 198.47 ms 198.98 ms]

Dependent ERC20/Origin Sequential
                        time:   [202.31 ms 202.79 ms 203.40 ms]
Dependent ERC20/Grevm Parallel
                        time:   [124.80 ms 125.38 ms 126.13 ms]
Dependent ERC20/Grevm Sequential
                        time:   [217.37 ms 217.85 ms 218.44 ms]
```
**After opt.**
```
Independent Raw Transfers/Origin Sequential
                        time:   [107.39 ms 107.46 ms 107.53 ms]
Independent Raw Transfers/Grevm Parallel
                        time:   [57.320 ms 57.444 ms 57.571 ms]
Independent Raw Transfers/Grevm Sequential
                        time:   [104.80 ms 105.02 ms 105.29 ms]

Dependent Raw Transfers/Origin Sequential
                        time:   [116.69 ms 116.73 ms 116.78 ms]
Dependent Raw Transfers/Grevm Parallel
                        time:   [72.225 ms 72.395 ms 72.564 ms]
Dependent Raw Transfers/Grevm Sequential
                        time:   [118.67 ms 118.74 ms 118.81 ms]

Independent ERC20/Origin Sequential
                        time:   [185.74 ms 185.92 ms 186.13 ms]
Independent ERC20/Grevm Parallel
                        time:   [86.406 ms 86.573 ms 86.743 ms]
Independent ERC20/Grevm Sequential
                        time:   [185.22 ms 185.31 ms 185.39 ms]

Dependent ERC20/Origin Sequential
                        time:   [203.41 ms 203.58 ms 203.79 ms]
Dependent ERC20/Grevm Parallel
                        time:   [113.27 ms 113.47 ms 113.67 ms]
Dependent ERC20/Grevm Sequential
                        time:   [202.92 ms 203.03 ms 203.14 ms]

```