### PR TITLE
Refactor(doc): add documentations and comments

### DIFF
--- a/tests/common/execute.rs
+++ b/tests/common/execute.rs
@@ -112,8 +112,7 @@ pub fn compare_evm_execute<DB>(
     let mut parallel_result = Err(GrevmError::UnreachableError(String::from("Init")));
     metrics::with_local_recorder(&recorder, || {
         let start = Instant::now();
-        let mut parallel =
-            GrevmScheduler::new(SpecId::LATEST, env.clone(), db.clone(), txs.clone());
+        let parallel = GrevmScheduler::new(SpecId::LATEST, env.clone(), db.clone(), txs.clone());
         // set determined partitions
         parallel_result = parallel.force_parallel_execute(with_hints, Some(23));
         println!("Grevm parallel execute time: {}ms", start.elapsed().as_millis());

--- a/tests/erc20/erc20_contract.rs
+++ b/tests/erc20/erc20_contract.rs
@@ -12,17 +12,17 @@ const ERC20_TOKEN: &str = include_str!("./contracts/ERC20Token.hex");
 // $ forge inspect ERC20Token methods
 
 lazy_static! {
-    pub static ref ERC20_ALLLOWANCE: U256 = U256::from(0xdd62ed3e as i64);
-    pub static ref ERC20_APPROVE: U256 = U256::from(0x095ea7b3 as i64);
-    pub static ref ERC20_BALANCE_OF: U256 = U256::from(0x70a08231 as i64);
-    pub static ref ERC20_DECIMALS: U256 = U256::from(0x313ce567 as i64);
-    pub static ref ERC20_DECREASE_ALLOWANCE: U256 = U256::from(0xa457c2d7 as i64);
-    pub static ref ERC20_INCREASE_ALLOWANCE: U256 = U256::from(0x39509351 as i64);
-    pub static ref ERC20_NAME: U256 = U256::from(0x06fdde03 as i64);
-    pub static ref ERC20_SYMBOL: U256 = U256::from(0x95d89b41 as i64);
-    pub static ref ERC20_TOTAL_SUPPLY: U256 = U256::from(0x18160ddd as i64);
-    pub static ref ERC20_TRANSFER: U256 = U256::from(0xa9059cbb as i64);
-    pub static ref ERC20_TRANSFER_FROM: U256 = U256::from(0x23b872dd as i64);
+    pub static ref ERC20_ALLLOWANCE: U256 = U256::from(0xdd62ed3e_i64);
+    pub static ref ERC20_APPROVE: U256 = U256::from(0x095ea7b3_i64);
+    pub static ref ERC20_BALANCE_OF: U256 = U256::from(0x70a08231_i64);
+    pub static ref ERC20_DECIMALS: U256 = U256::from(0x313ce567_i64);
+    pub static ref ERC20_DECREASE_ALLOWANCE: U256 = U256::from(0xa457c2d7_i64);
+    pub static ref ERC20_INCREASE_ALLOWANCE: U256 = U256::from(0x39509351_i64);
+    pub static ref ERC20_NAME: U256 = U256::from(0x06fdde03_i64);
+    pub static ref ERC20_SYMBOL: U256 = U256::from(0x95d89b41_i64);
+    pub static ref ERC20_TOTAL_SUPPLY: U256 = U256::from(0x18160ddd_i64);
+    pub static ref ERC20_TRANSFER: U256 = U256::from(0xa9059cbb_i64);
+    pub static ref ERC20_TRANSFER_FROM: U256 = U256::from(0x23b872dd_i64);
 }
 
 // @risechain/op-test-bench/foundry/src/ERC20Token.sol

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -28,7 +28,6 @@ use revme::cmd::statetest::{
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::str::FromStr;
 use walkdir::{DirEntry, WalkDir};
 
 #[path = "../common/mod.rs"]


### PR DESCRIPTION
## Add documentations and comments
And Fix tow bugs:
1. If can't skip all transactions, we should merge all write sets
2. Update the `update_write_set` in `PartitionExecutor::execute` when there exists an `Unconfirmed` transactions