### PR TITLE
fix(async_commit): relax caller nonce assertion for EIP-7702 self-auth

### DIFF
--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -117,8 +117,7 @@ where
                             let min_post = expect + 1;
                             let max_post = expect + 1 + self_auth_count;
                             assert!(
-                                change.info.nonce >= min_post
-                                    && change.info.nonce <= max_post,
+                                change.info.nonce >= min_post && change.info.nonce <= max_post,
                                 "post-state nonce {} out of range [{}, {}] for caller {:?} \
                                  (tx_type {}, self-auth count {})",
                                 change.info.nonce,
@@ -180,11 +179,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm_context::either::Either;
-    use revm_context::result::{Output, SuccessReason};
-    use revm_context::transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization};
+    use revm_context::{
+        either::Either,
+        result::{Output, SuccessReason},
+        transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization},
+    };
     use revm_database::EmptyDB;
-    use revm_primitives::{Address, B256, U256, Bytes, HashMap};
+    use revm_primitives::{Address, B256, Bytes, HashMap, U256};
     use revm_state::{Account, AccountInfo, AccountStatus, EvmStorage};
 
     fn make_account_info(nonce: u64) -> AccountInfo {
@@ -220,11 +221,7 @@ mod tests {
         }
     }
 
-    fn make_tx_env_with_auth(
-        caller: Address,
-        pre_nonce: u64,
-        authorities: Vec<Address>,
-    ) -> TxEnv {
+    fn make_tx_env_with_auth(caller: Address, pre_nonce: u64, authorities: Vec<Address>) -> TxEnv {
         let authorization_list = authorities
             .into_iter()
             .map(|authority| {
@@ -239,13 +236,7 @@ mod tests {
                 ))
             })
             .collect();
-        TxEnv {
-            tx_type: 4,
-            caller,
-            nonce: pre_nonce,
-            authorization_list,
-            ..Default::default()
-        }
+        TxEnv { tx_type: 4, caller, nonce: pre_nonce, authorization_list, ..Default::default() }
     }
 
     fn run_commit(state: &UnsafeCell<ParallelState<EmptyDB>>, tx_env: TxEnv, post_nonce: u64) {

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -2,7 +2,7 @@ use revm::{Database, DatabaseCommit, DatabaseRef};
 use revm_context::{
     TxEnv,
     result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
-    transaction::AuthorizationTr,
+    transaction::{AuthorizationTr, TransactionType},
 };
 use revm_primitives::Address;
 
@@ -103,30 +103,44 @@ where
                     if let Some(info) = info {
                         let expect = info.nonce;
                         if let Some(change) = state.get(&tx_env.caller) {
-                            // EIP-7702 (type-4) txs may bump the caller's nonce by more than 1:
-                            // once for the outer tx, plus once for each authorization tuple in
-                            // the same tx whose `authority == caller` and which passes revm's
-                            // per-tuple validation (chain_id / nonce / signature). The EIP
-                            // documents this broken monotonicity invariant in its Backwards
-                            // Compatibility section.
-                            let self_auth_count = tx_env
-                                .authorization_list
-                                .iter()
-                                .filter(|a| a.authority() == Some(tx_env.caller))
-                                .count() as u64;
-                            let min_post = expect + 1;
-                            let max_post = expect + 1 + self_auth_count;
-                            assert!(
-                                change.info.nonce >= min_post && change.info.nonce <= max_post,
-                                "post-state nonce {} out of range [{}, {}] for caller {:?} \
-                                 (tx_type {}, self-auth count {})",
-                                change.info.nonce,
-                                min_post,
-                                max_post,
-                                tx_env.caller,
-                                tx_env.tx_type,
-                                self_auth_count,
-                            );
+                            if tx_env.tx_type == TransactionType::Eip7702 as u8 {
+                                // EIP-7702 self-sponsored self-delegation can bump the caller's
+                                // nonce by more than 1: once for the outer tx, plus once for each
+                                // authorization tuple in the same tx whose `authority == caller`
+                                // that passes revm's per-tuple validation (chain_id /
+                                // existing-code / authority-nonce match / signature). The EIP
+                                // documents this broken monotonicity in its Backwards
+                                // Compatibility section.
+                                //
+                                // revm can skip individual tuples without reverting the tx, so
+                                // the precise applied count depends on dynamic state at the time
+                                // of processing — we can't cheaply re-derive it here without
+                                // duplicating revm's auth-list validation. The tightest invariant
+                                // we can assert is therefore a range: lower bound = outer tx
+                                // alone (any tuple may have been skipped); upper bound = all
+                                // self-auth tuples applied.
+                                let self_auth_count = tx_env
+                                    .authorization_list
+                                    .iter()
+                                    .filter(|a| a.authority() == Some(tx_env.caller))
+                                    .count()
+                                    as u64;
+                                let min_post = expect + 1;
+                                let max_post = expect + 1 + self_auth_count;
+                                assert!(
+                                    change.info.nonce >= min_post && change.info.nonce <= max_post,
+                                    "post-state nonce {} out of range [{}, {}] for caller {:?} \
+                                     (tx_type {}, self-auth count {})",
+                                    change.info.nonce,
+                                    min_post,
+                                    max_post,
+                                    tx_env.caller,
+                                    tx_env.tx_type,
+                                    self_auth_count,
+                                );
+                            } else {
+                                assert_eq!(change.info.nonce, expect + 1);
+                            }
                         }
                         match tx_env.nonce.cmp(&expect) {
                             Ordering::Greater => {
@@ -303,10 +317,11 @@ mod tests {
         run_commit(&state_cell, tx_env, pre_nonce + 2);
     }
 
-    /// Non-7702 path: empty `authorization_list`, post-state nonce = +2 → must still panic
-    /// (regression guard for the original invariant on legacy / 1559 / 4844 txs).
+    /// Non-7702 path: `tx_type != 4`, post-state nonce = +2 → must still panic via the
+    /// original strict equality (regression guard for legacy / 1559 / 4844 txs — panic
+    /// message format must stay bit-identical to upstream `assert_eq!`).
     #[test]
-    #[should_panic(expected = "post-state nonce")]
+    #[should_panic(expected = "left == right")]
     fn legacy_tx_plus_two_still_panics() {
         let caller = Address::from([0xCD; 20]);
         let pre_nonce = 1u64;

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -2,6 +2,7 @@ use revm::{Database, DatabaseCommit, DatabaseRef};
 use revm_context::{
     TxEnv,
     result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
+    transaction::AuthorizationTr,
 };
 use revm_primitives::Address;
 
@@ -102,7 +103,31 @@ where
                     if let Some(info) = info {
                         let expect = info.nonce;
                         if let Some(change) = state.get(&tx_env.caller) {
-                            assert_eq!(change.info.nonce, expect + 1);
+                            // EIP-7702 (type-4) txs may bump the caller's nonce by more than 1:
+                            // once for the outer tx, plus once for each authorization tuple in
+                            // the same tx whose `authority == caller` and which passes revm's
+                            // per-tuple validation (chain_id / nonce / signature). The EIP
+                            // documents this broken monotonicity invariant in its Backwards
+                            // Compatibility section.
+                            let self_auth_count = tx_env
+                                .authorization_list
+                                .iter()
+                                .filter(|a| a.authority() == Some(tx_env.caller))
+                                .count() as u64;
+                            let min_post = expect + 1;
+                            let max_post = expect + 1 + self_auth_count;
+                            assert!(
+                                change.info.nonce >= min_post
+                                    && change.info.nonce <= max_post,
+                                "post-state nonce {} out of range [{}, {}] for caller {:?} \
+                                 (tx_type {}, self-auth count {})",
+                                change.info.nonce,
+                                min_post,
+                                max_post,
+                                tx_env.caller,
+                                tx_env.tx_type,
+                                self_auth_count,
+                            );
                         }
                         match tx_env.nonce.cmp(&expect) {
                             Ordering::Greater => {
@@ -149,5 +174,170 @@ where
         // creating artificial dependencies.
         let coinbase = self.coinbase;
         assert!(self.state_mut().increment_balances(vec![(coinbase, lazy_reward)]).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm_context::either::Either;
+    use revm_context::result::{Output, SuccessReason};
+    use revm_context::transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization};
+    use revm_database::EmptyDB;
+    use revm_primitives::{Address, B256, U256, Bytes, HashMap};
+    use revm_state::{Account, AccountInfo, AccountStatus, EvmStorage};
+
+    fn make_account_info(nonce: u64) -> AccountInfo {
+        AccountInfo {
+            balance: U256::from(10u128.pow(18)),
+            nonce,
+            code_hash: B256::ZERO,
+            code: None,
+        }
+    }
+
+    fn make_result_and_state(caller: Address, post_nonce: u64) -> ResultAndState {
+        let mut state: HashMap<Address, Account> = HashMap::default();
+        state.insert(
+            caller,
+            Account {
+                info: make_account_info(post_nonce),
+                transaction_id: 0,
+                storage: EvmStorage::default(),
+                status: AccountStatus::Touched,
+            },
+        );
+        ResultAndState {
+            result: ExecutionResult::Success {
+                reason: SuccessReason::Stop,
+                gas_used: 21_000,
+                gas_refunded: 0,
+                logs: Vec::new(),
+                output: Output::Call(Bytes::new()),
+            },
+            state,
+            lazy_reward: 0,
+        }
+    }
+
+    fn make_tx_env_with_auth(
+        caller: Address,
+        pre_nonce: u64,
+        authorities: Vec<Address>,
+    ) -> TxEnv {
+        let authorization_list = authorities
+            .into_iter()
+            .map(|authority| {
+                let inner = Authorization {
+                    chain_id: U256::ZERO,
+                    address: Address::from([0xDE; 20]),
+                    nonce: pre_nonce + 1,
+                };
+                Either::Right(RecoveredAuthorization::new_unchecked(
+                    inner,
+                    RecoveredAuthority::Valid(authority),
+                ))
+            })
+            .collect();
+        TxEnv {
+            tx_type: 4,
+            caller,
+            nonce: pre_nonce,
+            authorization_list,
+            ..Default::default()
+        }
+    }
+
+    fn run_commit(state: &UnsafeCell<ParallelState<EmptyDB>>, tx_env: TxEnv, post_nonce: u64) {
+        let mut commit = StateAsyncCommit::new(
+            Address::ZERO,
+            CommitGuard::new(state),
+            false, // disable_nonce_check = false: exercise the assertion path
+        );
+        commit.init().expect("init");
+        commit.commit(0, &tx_env, make_result_and_state(tx_env.caller, post_nonce));
+        assert!(
+            commit.commit_result().is_ok(),
+            "commit_result should be Ok, got {:?}",
+            commit.commit_result()
+        );
+    }
+
+    /// EIP-7702 self-sponsored self-delegation: caller signs the outer tx AND lists itself
+    /// as an authority. revm bumps the caller's nonce twice (once for the tx, once for the
+    /// auth tuple), so post-state nonce = pre + 2. Without the EIP-7702-aware relaxation,
+    /// `assert_eq!(change.info.nonce, expect + 1)` panics with `left: 17, right: 16` — the
+    /// exact signature seen on Gravity testnet block 1400868.
+    #[test]
+    fn self_sponsored_self_delegation_nonce_plus_two_does_not_panic() {
+        let caller = Address::from([0xCA; 20]);
+        let pre_nonce = 15u64;
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(pre_nonce));
+        let state_cell = UnsafeCell::new(state);
+
+        let tx_env = make_tx_env_with_auth(caller, pre_nonce, vec![caller]);
+        run_commit(&state_cell, tx_env, pre_nonce + 2);
+    }
+
+    /// Two self-auth tuples in the same tx → caller nonce bumps +3. Upper bound of the new
+    /// assertion must scale with the count of `authority == caller` tuples.
+    #[test]
+    fn two_self_auth_tuples_nonce_plus_three_does_not_panic() {
+        let caller = Address::from([0xCB; 20]);
+        let pre_nonce = 7u64;
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(pre_nonce));
+        let state_cell = UnsafeCell::new(state);
+
+        let tx_env = make_tx_env_with_auth(caller, pre_nonce, vec![caller, caller]);
+        run_commit(&state_cell, tx_env, pre_nonce + 3);
+    }
+
+    /// Auth tuple whose authority is some *other* address must NOT widen the upper bound
+    /// for caller. A spurious +2 on caller should still panic — the relaxation is targeted,
+    /// not blanket.
+    #[test]
+    #[should_panic(expected = "post-state nonce")]
+    fn foreign_authority_does_not_widen_caller_bound() {
+        let caller = Address::from([0xCC; 20]);
+        let other = Address::from([0xAA; 20]);
+        let pre_nonce = 3u64;
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(pre_nonce));
+        let state_cell = UnsafeCell::new(state);
+
+        let tx_env = make_tx_env_with_auth(caller, pre_nonce, vec![other]);
+        // Foreign authority → max_post for caller is still pre + 1. Post = pre + 2 must panic.
+        run_commit(&state_cell, tx_env, pre_nonce + 2);
+    }
+
+    /// Non-7702 path: empty `authorization_list`, post-state nonce = +2 → must still panic
+    /// (regression guard for the original invariant on legacy / 1559 / 4844 txs).
+    #[test]
+    #[should_panic(expected = "post-state nonce")]
+    fn legacy_tx_plus_two_still_panics() {
+        let caller = Address::from([0xCD; 20]);
+        let pre_nonce = 1u64;
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(pre_nonce));
+        let state_cell = UnsafeCell::new(state);
+
+        let tx_env = TxEnv { caller, nonce: pre_nonce, ..Default::default() };
+        run_commit(&state_cell, tx_env, pre_nonce + 2);
+    }
+
+    /// Self-auth tx where the inner authorization is skipped by revm (e.g. nonce mismatch),
+    /// so only the outer tx bumps. Post = pre + 1 must still pass the lower bound.
+    #[test]
+    fn self_auth_but_only_outer_bump_passes() {
+        let caller = Address::from([0xCE; 20]);
+        let pre_nonce = 42u64;
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(pre_nonce));
+        let state_cell = UnsafeCell::new(state);
+
+        let tx_env = make_tx_env_with_auth(caller, pre_nonce, vec![caller]);
+        run_commit(&state_cell, tx_env, pre_nonce + 1);
     }
 }


### PR DESCRIPTION
## Summary
- Relax the caller-nonce assertion in `StateAsyncCommit::commit` so it stays valid for EIP-7702 (type-4) txs where `tx.from` is also one of the `authorization_list` authorities. The strict `change.info.nonce == expect + 1` correctly modelled the pre-Prague invariant but fires on the legitimate `+2` nonce bump that EIP-7702 itself documents in [Backwards Compatibility](https://eips.ethereum.org/EIPS/eip-7702#backwards-compatibility).
- Replace the equality with a range check: `[expect + 1, expect + 1 + count(auth.authority == caller)]`. For non-7702 txs the count is `0`, collapsing back to the original assertion — **zero behavioural change on legacy / 1559 / 4844**.
- Adds five module unit tests in `async_commit::tests`:
  - `self_sponsored_self_delegation_nonce_plus_two_does_not_panic` — repro of the testnet panic
  - `two_self_auth_tuples_nonce_plus_three_does_not_panic` — upper bound scales with self-auth count
  - `foreign_authority_does_not_widen_caller_bound` — `#[should_panic]`, relaxation is targeted
  - `legacy_tx_plus_two_still_panics` — `#[should_panic]`, non-7702 regression guard
  - `self_auth_but_only_outer_bump_passes` — lower-bound regression guard for the case where revm validation skips the auth tuple

## Context
This is a deterministic chain-halt on Gravity testnet (block 1400868, 2026-06-09) triggered by an EIP-7702 SetCode stress test — see Galxe/gravity-audit#677 for the full incident report and panic backtrace. The same panic is reachable on mainnet once a similar tx pattern is submitted (`simple-bench` 4000 worker accounts each self-sponsoring a self-delegation).

The root-cause hypothesis in the issue blamed an async-commit pipeline `commit_idx` off-by-one. On inspection of `async_commit.rs:78` at the deployed commit, the failing assertion is actually `assert_eq!(change.info.nonce, expect + 1)` — caller-account nonce monotonicity, not commit-index. The reported `left: 17 / right: 16` decodes to a `pre_nonce + 2` jump, consistent with self-sponsored self-delegation. EIP-7702 spec + the pinned `Galxe/revm@v29.0.1-gravity` fork + go-ethereum all confirm `+2` is correct behaviour for that case.

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` — 5 new UTs in `async_commit::tests` all pass
- [x] `cargo test --features test-utils` — erc20 (4), native_transfers (9), uniswap (1), doctest (1) all green
- [ ] Optional follow-up: end-to-end replay of testnet block 1400868 once incident-backup logs are accessible

Refs Galxe/gravity-audit#677