### PR TITLE
opt(coinbase): remove galxe/grevm dependency, and calculate rewards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,25 @@ license = "MIT OR Apache-2.0"
 autobins = false
 
 [dependencies]
-revm = { package = "revm", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
-revm-database = { package = "revm-database", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
-revm-state = { package = "revm-state", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
-revm-primitives = { package = "revm-primitives", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
-revm-inspector = { package = "revm-inspector", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
-revm-context = { package = "revm-context", git = "https://github.com/Galxe/revm", branch = "v29.0.1-gravity", default-features = false }
+# Upstream revm v29.0.1 (no fork). The miner reward is skipped during parallel execution via a
+# custom `Handler` (see `scheduler::NoRewardHandler`) and self-computed at commit time, so the
+# previous `Galxe/revm` fork (which only added a `lazy_reward` cfg flag + `ResultAndState` field)
+# is no longer needed.
+revm = { version = "29.0.1", default-features = false }
+revm-database = { version = "7.0.5", default-features = false }
+revm-state = { version = "7.0.5", default-features = false }
+revm-primitives = { version = "20.2.1", default-features = false }
+revm-inspector = { version = "10.0.1", default-features = false }
+revm-context = { version = "9.1.0", default-features = false }
 
 ahash = "0.8"
 rayon = "1.10.0"
 atomic = "0.6.0"
 parking_lot = "0.12"
 
-# Alloy
-alloy-evm = { package = "alloy-evm", git = "https://github.com/Galxe/alloy-evm", branch = "v0.21.3-gravity", default-features = false }
+# Alloy — upstream (the `Galxe/alloy-evm` fork only repointed revm to the gravity fork and added a
+# `..` to one `ResultAndState` destructure; both are unnecessary against upstream revm).
+alloy-evm = { version = "0.21.3", default-features = false }
 
 # async
 futures = "0.3"

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -1,9 +1,9 @@
 use revm::{Database, DatabaseCommit, DatabaseRef};
 use revm_context::{
-    TxEnv,
+    Transaction, TxEnv,
     result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
 };
-use revm_primitives::Address;
+use revm_primitives::{Address, hardfork::SpecId};
 
 use crate::{GrevmError, ParallelState, TxId};
 use std::{cell::UnsafeCell, cmp::Ordering};
@@ -37,6 +37,11 @@ where
     DB: DatabaseRef,
 {
     coinbase: Address,
+    /// Active hardfork — needed to self-compute the coinbase reward (EIP-1559 basefee burn from
+    /// LONDON onward).
+    spec: SpecId,
+    /// Block base fee per gas — the burned portion that does not reach the coinbase post-LONDON.
+    basefee: u64,
     results: Vec<ExecutionResult>,
     guard: CommitGuard<'a, DB>,
     commit_result: Result<(), GrevmError<DB::Error>>,
@@ -53,10 +58,37 @@ where
 {
     pub(crate) fn new(
         coinbase: Address,
+        spec: SpecId,
+        basefee: u64,
         guard: CommitGuard<'a, DB>,
         disable_nonce_check: bool,
     ) -> Self {
-        Self { coinbase, results: vec![], guard, commit_result: Ok(()), disable_nonce_check }
+        Self {
+            coinbase,
+            spec,
+            basefee,
+            results: vec![],
+            guard,
+            commit_result: Ok(()),
+            disable_nonce_check,
+        }
+    }
+
+    /// Self-compute the miner reward for one transaction, mirroring revm's
+    /// `post_execution::reward_beneficiary`: from LONDON the basefee is burned and only the
+    /// remainder of the effective gas price reaches the coinbase (EIP-1559).
+    ///
+    /// `result.gas_used()` is exactly the `gas.used()` (post-refund) that revm bills the reward on,
+    /// so this reproduces the forked revm's `lazy_reward` without relying on it.
+    fn compute_reward(&self, tx_env: &TxEnv, result: &ExecutionResult) -> u128 {
+        let basefee = self.basefee as u128;
+        let effective_gas_price = tx_env.effective_gas_price(basefee);
+        let coinbase_gas_price = if self.spec.is_enabled_in(SpecId::LONDON) {
+            effective_gas_price.saturating_sub(basefee)
+        } else {
+            effective_gas_price
+        };
+        coinbase_gas_price.saturating_mul(result.gas_used() as u128)
     }
 
     pub(crate) fn state_mut(&mut self) -> &mut ParallelState<DB> {
@@ -95,7 +127,12 @@ where
         // processing without immediate validation failures. However, during the final commitment
         // phase, the system enforces strict nonce monotonicity checks to guarantee transaction
         // integrity and prevent double-spending attacks.
-        let ResultAndState { result, state, lazy_reward } = result_and_state;
+        let ResultAndState { result, state } = result_and_state;
+        // Self-compute the miner reward: upstream revm credits the coinbase inside execution, which
+        // grevm suppresses with a custom `Handler` (see `scheduler::NoRewardHandler`) and applies
+        // here instead. This reproduces what the dropped `Galxe/revm` fork returned via
+        // `ResultAndState.lazy_reward`.
+        let reward = self.compute_reward(tx_env, &result);
         if !self.disable_nonce_check {
             match self.state_ref().basic_ref(tx_env.caller) {
                 Ok(info) => {
@@ -145,7 +182,7 @@ where
         // will read the proper miner state from ParallelState (verified via commit_idx) without
         // creating artificial dependencies.
         let coinbase = self.coinbase;
-        assert!(self.state_mut().increment_balances(vec![(coinbase, lazy_reward)]).is_ok());
+        assert!(self.state_mut().increment_balances(vec![(coinbase, reward)]).is_ok());
     }
 }
 
@@ -190,7 +227,6 @@ mod tests {
                 output: Output::Call(Bytes::new()),
             },
             state,
-            lazy_reward: 0,
         }
     }
 
@@ -215,6 +251,8 @@ mod tests {
     fn run_commit(state: &UnsafeCell<ParallelState<EmptyDB>>, tx_env: TxEnv, post_nonce: u64) {
         let mut commit = StateAsyncCommit::new(
             Address::ZERO,
+            SpecId::PRAGUE,
+            0, // basefee: with the tests' zero gas price the reward is 0 regardless
             CommitGuard::new(state),
             false, // disable_nonce_check = false: exercise the assertion path
         );
@@ -270,5 +308,47 @@ mod tests {
 
         let tx_env = make_tx_env_with_auth(caller, pre_nonce, vec![caller]);
         run_commit(&state_cell, tx_env, pre_nonce + 1);
+    }
+
+    /// `compute_reward` must mirror revm's `post_execution::reward_beneficiary`: pre-LONDON the
+    /// full effective gas price reaches the coinbase; from LONDON the basefee is burned (EIP-1559).
+    /// The mainnet replay harness clamps every pre-Shanghai block to `Merge`, so it never exercises
+    /// the pre-LONDON branch — this test pins both branches deterministically.
+    #[test]
+    fn compute_reward_matches_eip1559_basefee_burn() {
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        let state_cell = UnsafeCell::new(state);
+
+        let gas_used = 21_000u64;
+        let result = ExecutionResult::Success {
+            reason: SuccessReason::Stop,
+            gas_used,
+            gas_refunded: 0,
+            logs: Vec::new(),
+            output: Output::Call(Bytes::new()),
+        };
+        // Legacy tx: effective_gas_price == gas_price regardless of basefee.
+        let tx_env = TxEnv { gas_price: 100, gas_limit: gas_used, ..Default::default() };
+        let basefee = 10u64;
+
+        // Pre-LONDON: full price to coinbase, basefee NOT subtracted.
+        let pre = StateAsyncCommit::new(
+            Address::ZERO,
+            SpecId::BERLIN,
+            basefee,
+            CommitGuard::new(&state_cell),
+            true,
+        );
+        assert_eq!(pre.compute_reward(&tx_env, &result), 100u128 * gas_used as u128);
+
+        // LONDON+: basefee burned, only the priority portion reaches the coinbase.
+        let post = StateAsyncCommit::new(
+            Address::ZERO,
+            SpecId::LONDON,
+            basefee,
+            CommitGuard::new(&state_cell),
+            true,
+        );
+        assert_eq!(post.compute_reward(&tx_env, &result), (100u128 - 10) * gas_used as u128);
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -18,15 +18,21 @@ use metrics::histogram;
 use metrics_derive::Metrics;
 use parking_lot::Mutex;
 use revm::{
-    Context, DatabaseCommit, DatabaseRef, MainBuilder, MainContext,
+    Context, DatabaseCommit, DatabaseRef, ExecuteEvm, MainBuilder, MainContext,
+    context::Evm as RevmEvm,
+    handler::{
+        EthFrame, EvmTr, EvmTrError, FrameResult, FrameTr, Handler, instructions::EthInstructions,
+    },
+    interpreter::{interpreter::EthInterpreter, interpreter_action::FrameInit},
     precompile::{PrecompileSpecId, Precompiles},
 };
 use revm_context::{
-    BlockEnv, CfgEnv, TxEnv,
-    result::{EVMError, ExecutionResult},
+    BlockEnv, CfgEnv, ContextSetters, ContextTr, JournalTr, TxEnv,
+    result::{EVMError, ExecutionResult, HaltReason, ResultAndState},
 };
 use revm_inspector::NoOpInspector;
 use revm_primitives::Address;
+use revm_state::EvmState;
 
 use std::{
     cell::UnsafeCell,
@@ -42,6 +48,55 @@ use std::{
 };
 
 pub(crate) type MVMemory = DashMap<LocationAndType, BTreeMap<TxId, MemoryEntry>>;
+
+/// The mainnet EVM context grevm executes against on the parallel path (an `EthEvm`-shaped stack).
+type GrevmCtx<'a, DB> = Context<BlockEnv, TxEnv, CfgEnv, CacheDB<'a, ParallelState<DB>>>;
+
+/// The raw revm EVM, unwrapped from alloy's `EthEvm`, so we can drive a custom [`Handler`] that
+/// skips the miner reward during execution.
+type GrevmEvm<'a, DB> = RevmEvm<
+    GrevmCtx<'a, DB>,
+    NoOpInspector,
+    EthInstructions<EthInterpreter, GrevmCtx<'a, DB>>,
+    PrecompilesMap,
+    EthFrame,
+>;
+
+/// A mainnet [`Handler`] that suppresses the beneficiary (miner) reward. Instead of crediting the
+/// coinbase inside transaction execution — which would make every transaction read & write the
+/// coinbase account and thus conflict — grevm defers the reward and applies it at commit time (see
+/// [`crate::async_commit::StateAsyncCommit::compute_reward`]). This mirrors revm's `MainnetHandler`
+/// with only `reward_beneficiary` overridden to a no-op, and replaces the old `Galxe/revm` fork's
+/// `cfg.lazy_reward` flag so grevm can build against upstream revm.
+struct NoRewardHandler<EVM, ERROR, FRAME> {
+    _phantom: core::marker::PhantomData<(EVM, ERROR, FRAME)>,
+}
+
+impl<EVM, ERROR, FRAME> Default for NoRewardHandler<EVM, ERROR, FRAME> {
+    fn default() -> Self {
+        Self { _phantom: core::marker::PhantomData }
+    }
+}
+
+impl<EVM, ERROR, FRAME> Handler for NoRewardHandler<EVM, ERROR, FRAME>
+where
+    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState>>, Frame = FRAME>,
+    ERROR: EvmTrError<EVM>,
+    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+{
+    type Evm = EVM;
+    type Error = ERROR;
+    type HaltReason = HaltReason;
+
+    /// Skip the miner reward; grevm applies it lazily at commit time.
+    fn reward_beneficiary(
+        &self,
+        _evm: &mut Self::Evm,
+        _exec_result: &mut FrameResult,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
 
 #[derive(Metrics)]
 #[metrics(scope = "grevm")]
@@ -365,12 +420,6 @@ where
                 }
                 let mut tx_state = self.tx_states[finality_idx].lock();
                 if tx_state.status != TransactionStatus::Unconfirmed {
-                    tracing::warn!(target: "grevm::scheduler",
-                        block_number = %self.env.number,
-                        finality_idx = finality_idx,
-                        tx_status = ?tx_state.status,
-                        "transaction shoud by marked as finality, but with wrong status"
-                    );
                     break;
                 }
                 tx_state.status = TransactionStatus::Finality;
@@ -456,6 +505,8 @@ where
         }
         let commiter = Mutex::new(StateAsyncCommit::new(
             self.env.beneficiary,
+            self.cfg.spec,
+            self.env.basefee,
             CommitGuard::new(&self.state),
             self.cfg.disable_nonce_check,
         ));
@@ -482,11 +533,13 @@ where
                         &self.scheduler_ctx.commit_idx,
                     );
                     let mut cfg = self.cfg.clone();
-                    // Disable noce check to bypass the EVM's strict sequential
-                    // nonce verification, but the nonce will be checked when transaction commit
+                    // Disable nonce check to bypass the EVM's strict sequential nonce verification;
+                    // the nonce is re-checked when the transaction commits.
                     cfg.disable_nonce_check = true;
-                    cfg.lazy_reward = true;
-                    let evm = Context::mainnet()
+                    // Build the raw revm EVM (not wrapped in `EthEvm`) so we can drive a custom
+                    // `Handler` that skips the miner reward — the reward is deferred and applied at
+                    // commit time (see `async_commit`).
+                    let mut evm = Context::mainnet()
                         .with_db(cache_db)
                         .with_cfg(cfg)
                         .with_block(self.env.clone())
@@ -494,12 +547,10 @@ where
                         .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
                             PrecompileSpecId::from_spec_id(self.cfg.spec),
                         )));
-                    let mut evm = EthEvm::new(evm, false);
                     // Apply additional precompiles if provided
                     for (address, precompile) in self.custom_precompiles.iter() {
                         let precompile_clone = precompile.clone();
-                        evm.precompiles_mut()
-                            .apply_precompile(&address, move |_| Some(precompile_clone));
+                        evm.precompiles.apply_precompile(&address, move |_| Some(precompile_clone));
                     }
 
                     let mut task = self.next();
@@ -617,11 +668,7 @@ where
     /// - ​Unconfirmed Miner/Self-Destruct Accounts: The transaction interacts with miner rewards or
     ///   self-destructed accounts before their committing transaction is finalized (txid ≠
     ///   commit_idx)
-    fn execute(
-        &self,
-        evm: &mut EthEvm<CacheDB<ParallelState<DB>>, NoOpInspector, PrecompilesMap>,
-        tx_version: TxVersion,
-    ) -> Option<Task> {
+    fn execute(&self, evm: &mut GrevmEvm<'_, DB>, tx_version: TxVersion) -> Option<Task> {
         let TxVersion { txid, incarnation } = tx_version;
         let mut tx_state = self.tx_states[txid].lock();
         if tx_state.status != TransactionStatus::Executing {
@@ -635,7 +682,18 @@ where
         evm.db_mut().reset_state(TxVersion::new(txid, incarnation));
         let tx_env = self.txs[txid].clone();
         let commit_idx = self.scheduler_ctx.commit_idx.load(Ordering::Acquire);
-        let result = evm.transact_raw(tx_env);
+        // Execute with the miner reward suppressed (see `NoRewardHandler`); the reward is applied
+        // later in `async_commit`. This replicates revm's `ExecuteEvm::transact` (set tx → run
+        // handler → finalize) but with our handler instead of the default `MainnetHandler`.
+        //
+        // `finalize` clears the journal and MUST run even when execution errors: this EVM is reused
+        // for the next transaction on the same thread, so a dirty journal left by a failed
+        // (optimistic) tx would corrupt the following one. revm's `transact` finalizes
+        // unconditionally and only then propagates the error — we do the same.
+        evm.ctx.set_tx(tx_env);
+        let output_or_error = NoRewardHandler::default().run(evm);
+        let state = evm.finalize();
+        let result = output_or_error.map(|result| ResultAndState { result, state });
 
         // The `​write_new_locations` mechanism optimizes validation by intelligently reducing
         // redundant verification tasks. Under standard validation logic, when a conflicted


### PR DESCRIPTION
## Summary

Drop the `Galxe/revm` + `Galxe/alloy-evm` forks; grevm now builds against upstream crates.io `revm 29.0.1` / `alloy-evm 0.21.3`.

## Background

The fork existed only to add a `lazy_reward` cfg flag: during parallel execution the coinbase reward must be skipped — otherwise every transaction reads & writes the beneficiary account and serializes on it — and the amount returned afterward for crediting. This PR reimplements that inside grevm, so the fork (and the cost of maintaining it) is no longer needed.

## Changes

- **Skip the reward during execution** — the parallel path now drives the raw `revm::Evm` with a custom `scheduler::NoRewardHandler`: a `MainnetHandler` clone with `reward_beneficiary` overridden to a no-op. This replaces alloy's `EthEvm` + `cfg.lazy_reward`.
- **Credit the coinbase at commit time** — `async_commit::StateAsyncCommit::compute_reward` self-computes the miner reward, mirroring revm's `post_execution::reward_beneficiary` (EIP-1559 basefee burn from LONDON onward). `StateAsyncCommit` gains `spec` + `basefee`.
- **Unconditional `finalize()`** — the per-thread EVM is reused across transactions, so the journal is finalized (cleared) even when a tx errors, exactly as revm's `ExecuteEvm::transact` does. A failed optimistic tx must not leave a dirty journal for the next one on that thread.

## Testing

- New unit test pinning both reward branches (pre-LONDON full effective gas price vs LONDON+ basefee burn).
- Mainnet replay harness (grevm parallel == sequential revm, byte-for-byte including the coinbase balance) across forks Berlin → Prague and large merged "big block" fixtures.
