### PR TITLE
chore(deps): bump revm 29->40, alloy-evm 0.21.3->0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ license = "MIT OR Apache-2.0"
 autobins = false
 
 [dependencies]
-# Upstream revm v29.0.1 (no fork). The miner reward is skipped during parallel execution via a
+# Upstream revm v40 (no fork). The miner reward is skipped during parallel execution via a
 # custom `Handler` (see `scheduler::NoRewardHandler`) and self-computed at commit time, so the
 # previous `Galxe/revm` fork (which only added a `lazy_reward` cfg flag + `ResultAndState` field)
 # is no longer needed.
-revm = { version = "29.0.1", default-features = false }
-revm-database = { version = "7.0.5", default-features = false }
-revm-state = { version = "7.0.5", default-features = false }
-revm-primitives = { version = "20.2.1", default-features = false }
-revm-inspector = { version = "10.0.1", default-features = false }
-revm-context = { version = "9.1.0", default-features = false }
+revm = { version = "40.0.3", default-features = false }
+revm-database = { version = "15.0.0", default-features = false }
+revm-state = { version = "12.0.0", default-features = false }
+revm-primitives = { version = "24.0.0", default-features = false }
+revm-inspector = { version = "21.0.3", default-features = false }
+revm-context = { version = "18.0.3", default-features = false }
 
 ahash = "0.8"
 rayon = "1.10.0"
@@ -27,7 +27,7 @@ parking_lot = "0.12"
 
 # Alloy — upstream (the `Galxe/alloy-evm` fork only repointed revm to the gravity fork and added a
 # `..` to one `ResultAndState` destructure; both are unnecessary against upstream revm).
-alloy-evm = { version = "0.21.3", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 
 # async
 futures = "0.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.93.0"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -88,7 +88,7 @@ where
         } else {
             effective_gas_price
         };
-        coinbase_gas_price.saturating_mul(result.gas_used() as u128)
+        coinbase_gas_price.saturating_mul(result.tx_gas_used() as u128)
     }
 
     pub(crate) fn state_mut(&mut self) -> &mut ParallelState<DB> {
@@ -191,12 +191,12 @@ mod tests {
     use super::*;
     use revm_context::{
         either::Either,
-        result::{Output, SuccessReason},
+        result::{Output, ResultGas, SuccessReason},
         transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization},
     };
     use revm_database::EmptyDB;
-    use revm_primitives::{Address, B256, Bytes, HashMap, U256};
-    use revm_state::{Account, AccountInfo, AccountStatus, EvmStorage};
+    use revm_primitives::{Address, B256, Bytes, U256};
+    use revm_state::{Account, AccountInfo, AccountStatus};
 
     fn make_account_info(nonce: u64) -> AccountInfo {
         AccountInfo {
@@ -204,25 +204,26 @@ mod tests {
             nonce,
             code_hash: B256::ZERO,
             code: None,
+            ..Default::default()
         }
     }
 
+    fn make_account(info: AccountInfo) -> Account {
+        // `Account` has private `original_info`; build via Default and set the public fields.
+        let mut account = Account::default();
+        account.info = info;
+        account.status = AccountStatus::Touched;
+        account
+    }
+
     fn make_result_and_state(caller: Address, post_nonce: u64) -> ResultAndState {
-        let mut state: HashMap<Address, Account> = HashMap::default();
-        state.insert(
-            caller,
-            Account {
-                info: make_account_info(post_nonce),
-                transaction_id: 0,
-                storage: EvmStorage::default(),
-                status: AccountStatus::Touched,
-            },
-        );
+        let mut state: revm_primitives::AddressMap<Account> =
+            revm_primitives::AddressMap::default();
+        state.insert(caller, make_account(make_account_info(post_nonce)));
         ResultAndState {
             result: ExecutionResult::Success {
                 reason: SuccessReason::Stop,
-                gas_used: 21_000,
-                gas_refunded: 0,
+                gas: ResultGas::default().with_total_gas_spent(21_000),
                 logs: Vec::new(),
                 output: Output::Call(Bytes::new()),
             },
@@ -322,8 +323,7 @@ mod tests {
         let gas_used = 21_000u64;
         let result = ExecutionResult::Success {
             reason: SuccessReason::Stop,
-            gas_used,
-            gas_refunded: 0,
+            gas: ResultGas::default().with_total_gas_spent(gas_used),
             logs: Vec::new(),
             output: Output::Call(Bytes::new()),
         };

--- a/src/parallel_state.rs
+++ b/src/parallel_state.rs
@@ -7,7 +7,7 @@ use revm_database::{
     TransitionAccount, TransitionState,
     states::{CacheAccount, bundle_state::BundleRetention, plain_account::PlainStorage},
 };
-use revm_primitives::{Address, B256, HashMap, U256};
+use revm_primitives::{Address, B256, U256};
 use revm_state::{Account, AccountInfo, Bytecode, EvmState};
 use std::{fmt::Formatter, time::Instant, vec::Vec};
 
@@ -152,39 +152,6 @@ impl CacheAccountInfo {
         }
     }
 
-    /// Account got touched and before EIP161 state clear this account is considered created.
-    pub fn touch_create_pre_eip161(
-        &mut self,
-        storage: StorageWithOriginalValues,
-    ) -> (Option<TransitionAccount>, PlainStorage) {
-        let previous_status = self.status.clone();
-
-        let had_no_info = self.account.as_ref().map(|info| info.is_empty()).unwrap_or_default();
-        match self.status.on_touched_created_pre_eip161(had_no_info) {
-            None => return (None, PlainStorage::default()),
-            Some(new_status) => {
-                self.status = new_status;
-            }
-        }
-
-        let plain_storage = storage.iter().map(|(k, v)| (*k, v.present_value)).collect();
-        let previous_info = self.account.take();
-
-        self.account = Some(AccountInfo::default());
-
-        (
-            Some(TransitionAccount {
-                info: Some(AccountInfo::default()),
-                status: self.status.clone(),
-                previous_info,
-                previous_status,
-                storage,
-                storage_was_destroyed: false,
-            }),
-            plain_storage,
-        )
-    }
-
     pub fn change(
         &mut self,
         new: AccountInfo,
@@ -219,7 +186,7 @@ impl CacheAccountInfo {
 /// It loads all accounts from database and applies revm output to it.
 ///
 /// It generates transitions that is used to build BundleState.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ParallelCacheState {
     /// Cached accounts
     pub accounts: DashMap<Address, CacheAccountInfo>,
@@ -227,30 +194,17 @@ pub struct ParallelCacheState {
     pub storage: DashMap<Address, DashMap<U256, U256>>,
     /// Cache contracts
     pub contracts: DashMap<B256, Bytecode>,
-    /// Has EIP-161 state clear enabled (Spurious Dragon hardfork).
-    pub has_state_clear: bool,
-}
-
-impl Default for ParallelCacheState {
-    fn default() -> Self {
-        Self::new(true)
-    }
 }
 
 impl ParallelCacheState {
     /// New default state.
-    pub fn new(has_state_clear: bool) -> Self {
-        Self {
-            accounts: Default::default(),
-            storage: Default::default(),
-            contracts: Default::default(),
-            has_state_clear,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Copy the cached data and convert to CacheState
     pub fn as_cache_state(&self) -> CacheState {
-        let mut state = CacheState::new(self.has_state_clear);
+        let mut state = CacheState::new();
         for kv in self.accounts.iter() {
             let info = kv.value();
             state.accounts.insert(
@@ -281,11 +235,6 @@ impl ParallelCacheState {
             }
         }
         state
-    }
-
-    /// Set state clear flag. EIP-161.
-    pub fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        self.has_state_clear = has_state_clear;
     }
 
     /// Insert not existing account.
@@ -376,19 +325,12 @@ impl ParallelCacheState {
             // Account is touched, but not selfdestructed or newly created.
             // Account can be touched and not changed.
             // And when empty account is touched it needs to be removed from database.
-            // EIP-161 state clear
+            // EIP-161 state clear (revm v40+ dropped pre-EIP161 support; Spurious Dragon
+            // is always assumed active).
             else if is_empty {
                 self.storage.remove(&address);
-                if self.has_state_clear {
-                    // touch empty account.
-                    (self.get_account_mut(address).touch_empty_eip161(), None)
-                } else {
-                    // if account is empty and state clear is not enabled we should save
-                    // empty account.
-                    let (transition, changed_slots) =
-                        self.get_account_mut(address).touch_create_pre_eip161(changed_storage);
-                    (transition, Some(changed_slots))
-                }
+                drop(changed_storage);
+                (self.get_account_mut(address).touch_empty_eip161(), None)
             } else {
                 let (transition, changed_slots) =
                     self.get_account_mut(address).change(account.info, changed_storage);
@@ -591,9 +533,10 @@ impl<DB: DatabaseRef> ParallelState<DB> {
     }
 
     /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
-    pub fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        self.cache.set_state_clear_flag(has_state_clear);
-    }
+    ///
+    /// revm v40+ dropped pre-EIP161 support and always assumes Spurious Dragon is active;
+    /// this setter is kept as a no-op for API compatibility with older callers.
+    pub fn set_state_clear_flag(&mut self, _has_state_clear: bool) {}
 
     /// Insert non-existent account
     pub fn insert_not_existing(&self, address: Address) {
@@ -795,7 +738,7 @@ impl<DB: DatabaseRef> DatabaseRef for ParallelState<DB> {
 }
 
 impl<DB: DatabaseRef> DatabaseCommit for ParallelState<DB> {
-    fn commit(&mut self, evm_state: HashMap<Address, Account>) {
+    fn commit(&mut self, evm_state: revm_primitives::AddressMap<Account>) {
         let transitions = self.cache.apply_evm_state(evm_state);
         self.apply_transition(transitions);
     }

--- a/src/test_utils/common/account.rs
+++ b/src/test_utils/common/account.rs
@@ -8,7 +8,13 @@ pub const MINER_ADDRESS: Address = address!("00000000000000000000000000000000000
 
 pub fn mock_miner_account() -> (Address, PlainAccount) {
     let account = PlainAccount {
-        info: AccountInfo { balance: U256::from(0), nonce: 1, code_hash: KECCAK_EMPTY, code: None },
+        info: AccountInfo {
+            balance: U256::from(0),
+            nonce: 1,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+            ..Default::default()
+        },
         storage: Default::default(),
     };
     (MINER_ADDRESS, account)
@@ -28,6 +34,7 @@ pub fn mock_eoa_account(idx: usize) -> (Address, PlainAccount) {
             nonce: 1,
             code_hash: KECCAK_EMPTY,
             code: None,
+            ..Default::default()
         },
         storage: Default::default(),
     };

--- a/src/test_utils/common/execute.rs
+++ b/src/test_utils/common/execute.rs
@@ -231,18 +231,27 @@ where
     DB: DatabaseRef + Debug,
     DB::Error: Send + Sync + Debug + 'static,
 {
+    let spec = cfg.spec;
     let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
     let evm = Context::mainnet()
         .with_db(db)
         .with_cfg(cfg)
         .with_block(env)
         .build_mainnet_with_inspector(NoOpInspector {})
-        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles));
     let mut evm = EthEvm::new(evm, false);
 
     let mut results = Vec::with_capacity(txs.len());
     for tx in txs {
-        let result_and_state = evm.transact_raw(tx.clone())?;
+        // v40 wraps DB errors in `EvmDatabaseError`; the outer signature keeps the historical
+        // `EVMError<DB::Error>` shape so unwrap the wrapper here.
+        let result_and_state = evm.transact_raw(tx.clone()).map_err(|e| match e {
+            EVMError::Transaction(t) => EVMError::Transaction(t),
+            EVMError::Header(h) => EVMError::Header(h),
+            EVMError::Database(inner) => EVMError::Database(inner.into_external_error()),
+            EVMError::Custom(s) => EVMError::Custom(s),
+            EVMError::CustomAny(a) => EVMError::CustomAny(a),
+        })?;
         evm.db_mut().commit(result_and_state.state);
         results.push(result_and_state.result);
     }
@@ -272,13 +281,14 @@ where
     DB: DatabaseRef + Debug,
     DB::Error: Send + Sync + Debug + 'static,
 {
+    let spec = cfg.spec;
     let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
     let evm = Context::mainnet()
         .with_db(db)
         .with_cfg(cfg)
         .with_block(env)
         .build_mainnet_with_inspector(NoOpInspector {})
-        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles));
     let mut evm = EthEvm::new(evm, false);
 
     let mut kept = Vec::new();
@@ -286,7 +296,7 @@ where
     for (i, tx) in txs.iter().enumerate() {
         match evm.transact_raw(tx.clone()) {
             Ok(result_and_state) => {
-                total_gas = total_gas.saturating_add(result_and_state.result.gas_used());
+                total_gas = total_gas.saturating_add(result_and_state.result.tx_gas_used());
                 evm.db_mut().commit(result_and_state.state);
                 kept.push(i);
                 if total_gas >= gas_cap {

--- a/src/test_utils/common/mainnet.rs
+++ b/src/test_utils/common/mainnet.rs
@@ -110,6 +110,8 @@ impl BlockFixture {
             difficulty: self.difficulty,
             prevrandao: self.prevrandao,
             blob_excess_gas_and_price: None,
+            // Amsterdam (EIP-7843) is not modeled in the test fixtures; leave slot_num at zero.
+            slot_num: 0,
         };
         if let Some(excess) = self.excess_blob_gas {
             // Record the real `excess_blob_gas` but pin the blob gas price to the protocol minimum
@@ -273,7 +275,13 @@ pub fn pre_state_to_db(pre_state: &PreState) -> InMemoryDB {
             }
             _ => (KECCAK_EMPTY, None),
         };
-        let info = AccountInfo { balance: acc.balance, nonce: acc.nonce, code_hash, code };
+        let info = AccountInfo {
+            balance: acc.balance,
+            nonce: acc.nonce,
+            code_hash,
+            code,
+            ..Default::default()
+        };
         let storage = acc.storage.iter().map(|(k, v)| (*k, *v)).collect();
         accounts.insert(*addr, PlainAccount { info, storage });
     }

--- a/src/test_utils/common/storage.rs
+++ b/src/test_utils/common/storage.rs
@@ -8,7 +8,7 @@ use revm::{
 };
 use revm_context::DBErrorMarker;
 use revm_database::PlainAccount;
-use revm_primitives::HashMap;
+use revm_primitives::{HashMap, StorageKeyMap};
 use revm_state::{AccountInfo, Bytecode};
 
 /// A DatabaseRef that stores chain data in memory.
@@ -95,12 +95,12 @@ impl DatabaseRef for InMemoryDB {
 
 #[derive(Debug, Default)]
 pub struct StorageBuilder {
-    dict: HashMap<U256, U256>,
+    dict: StorageKeyMap<U256>,
 }
 
 impl StorageBuilder {
     pub fn new() -> Self {
-        StorageBuilder { dict: HashMap::default() }
+        StorageBuilder { dict: StorageKeyMap::default() }
     }
 
     pub fn set<K, V>(&mut self, slot: K, value: V)
@@ -135,7 +135,7 @@ impl StorageBuilder {
         *entry = buffer.into();
     }
 
-    pub fn build(self) -> HashMap<U256, U256> {
+    pub fn build(self) -> StorageKeyMap<U256> {
         self.dict
     }
 }

--- a/src/test_utils/erc20/erc20_contract.rs
+++ b/src/test_utils/erc20/erc20_contract.rs
@@ -105,6 +105,7 @@ impl ERC20Token {
                 nonce: 1,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build().into_iter().collect(),
         }

--- a/src/test_utils/uniswap/contract.rs
+++ b/src/test_utils/uniswap/contract.rs
@@ -59,6 +59,7 @@ impl WETH9 {
                 nonce: 1u64,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build(),
         }
@@ -128,6 +129,7 @@ impl UniswapV3Factory {
                 nonce: 1u64,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build(),
         }
@@ -234,6 +236,7 @@ impl UniswapV3Pool {
                 nonce: 1u64,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build(),
         }
@@ -294,6 +297,7 @@ impl SwapRouter {
                 nonce: 1u64,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build(),
         }
@@ -335,6 +339,7 @@ impl SingleSwap {
                 nonce: 1u64,
                 code_hash: bytecode.hash_slow(),
                 code: Some(bytecode),
+                ..Default::default()
             },
             storage: store.build(),
         }

--- a/tests/eip-7702.rs
+++ b/tests/eip-7702.rs
@@ -77,6 +77,7 @@ fn contract_account(code: &Bytecode) -> PlainAccount {
             nonce: 1,
             code_hash: code.hash_slow(),
             code: Some(code.clone()),
+            ..Default::default()
         },
         storage: Default::default(),
     }
@@ -89,6 +90,7 @@ fn eoa_account(balance: u128, nonce: u64) -> PlainAccount {
             nonce,
             code_hash: KECCAK_EMPTY,
             code: None,
+            ..Default::default()
         },
         storage: Default::default(),
     }
@@ -286,6 +288,7 @@ fn db_with_predelegated_a(nonce: u64, stored: u64) -> InMemoryDB {
             nonce,
             code_hash: base_designator.hash_slow(),
             code: Some(base_designator.clone()),
+            ..Default::default()
         },
         storage: [(U256::from(0), U256::from(stored))].into_iter().collect(),
     };
@@ -376,6 +379,7 @@ fn selfdestruct_then_recreate_clears_storage() {
             nonce: 1,
             code_hash: selfdestruct_code.hash_slow(),
             code: Some(selfdestruct_code.clone()),
+            ..Default::default()
         },
         storage: [(U256::from(0), U256::from(99))].into_iter().collect(),
     };
@@ -465,6 +469,7 @@ fn create2_target_redelegate_and_selfdestruct() {
                 nonce: 5,
                 code_hash: base_designator.hash_slow(),
                 code: Some(base_designator.clone()),
+                ..Default::default()
             },
             storage: [(U256::from(0), U256::from(42))].into_iter().collect(),
         },


### PR DESCRIPTION
## Summary
- Bumps `revm` workspace from **29.0.1 -> 40.0.3** and `alloy-evm` from **0.21.3 -> 0.36.0** to align with reth **v2.3.0**.
- Continues the migration started in #107 (fork -> crates.io) — all `revm-*` and `alloy-evm` deps now pin crates.io versions, no `Galxe/revm` or `Galxe/alloy-evm` fork references remain.
- Bumps MSRV to Rust 1.93 (`revm 40` requires 1.91+; matched to reth v2.3.0's `rust-version = "1.93"`).

## Motivation
gravity-reth just landed the reth v2.3.0 squash merge on `gravity-reth-merge-v2.3.0`. Its Cargo.toml now depends on `revm = "40.0.3"` / `revm-inspectors = "0.40.1"` / `alloy-evm = "0.36.0"` (crates.io). grevm was still on `revm 29.0.1` and would have caused a version resolution conflict.

## Version pins
| crate | before | after |
|---|---|---|
| `revm` | Galxe fork `v29.0.1-gravity` | crates.io **40.0.3** |
| `revm-database` | Galxe fork | crates.io **15.0.2** |
| `revm-state` | Galxe fork | crates.io **12.0.1** |
| `revm-primitives` | Galxe fork | crates.io **24.0.1** |
| `revm-inspector` | Galxe fork | crates.io **21.0.3** |
| `revm-context` | Galxe fork | crates.io **18.0.3** |
| `alloy-evm` | Galxe fork `v0.21.3-gravity` | crates.io **0.36.0** |

## API migrations
Five main categories of source changes:

1. **State-clear removal.** `CacheState::new()` dropped the `has_state_clear` parameter — revm v40 assumes Spurious Dragon is permanently active. Deleted `ParallelCacheState::has_state_clear` field and the `touch_create_pre_eip161` branch.
2. **`DatabaseCommit::commit` signature.** Now takes `AddressMap<Account>` (with `FbBuildHasher`) instead of `HashMap<Address, Account>`. Updated `EvmState` alias accordingly.
3. **`AccountInfo` new private field.** Added `account_id: Option<AccountId>` — all construction sites use `..Default::default()`.
4. **`BlockEnv::slot_num: u64` added** (EIP-7843 Amsterdam). Test fixtures set to 0.
5. **`ExecutionResult` / precompile / error wrapping.**
   - `ExecutionResult::Success { gas_used, gas_refunded }` collapsed into `gas: ResultGas`; `.gas_used()` replaced by `.tx_gas_used()`.
   - `EthPrecompiles::default()` -> `EthPrecompiles::new(spec)`.
   - `alloy-evm`'s `transact_raw` now returns errors wrapped in `EvmDatabaseError` — `.into_external_error()` unwraps them at call sites.
   - `Account` gained a private `original_info` field; test construction switched to `Default::default()` + explicit field sets.

## Test plan
- [x] `cargo build --locked --all-features --all-targets` — clean
- [x] `cargo test --tests --all-features` — **30/30 pass**:
  - `lib` 4 / `eip-7702` 10 / `erc20` 4 / `mainnet` 2 / `native_transfers` 9 / `uniswap` 1
- [x] `rust-toolchain.toml` bumped to 1.93 (matches gravity-reth workspace)