### PR TITLE
fix(storage): account reverts_size in parallel bundle path

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -72,6 +72,7 @@ impl ParallelBundleState for BundleState {
         let reverts = DisjointVec::new(vec![None; reverts_capacity]);
         let bundle_state = DisjointVec::new(vec![None; transitions.len()]);
         let state_size = AtomicUsize::new(0);
+        let reverts_size = AtomicUsize::new(0);
         let contracts = Mutex::new(revm_primitives::HashMap::default());
 
         fork_join_util(transitions.len(), None, |start_pos, end_pos, _| {
@@ -88,12 +89,14 @@ impl ParallelBundleState for BundleState {
                     state_size.fetch_add(present_bundle.size_hint(), Ordering::Relaxed);
                     unsafe { bundle_state.set(pos, Some((address, present_bundle))) };
                     if include_reverts {
+                        reverts_size.fetch_add(revert.size_hint(), Ordering::Relaxed);
                         unsafe { reverts.set(pos, Some((address, revert))) };
                     }
                 }
             }
         });
         self.state_size = state_size.load(Ordering::Acquire);
+        self.reverts_size = reverts_size.load(Ordering::Acquire);
 
         // much faster than bundle_state.into_iter().filter_map(|r| r).collect()
         self.state.reserve(transitions.len());

--- a/src/test_utils/common/execute.rs
+++ b/src/test_utils/common/execute.rs
@@ -86,6 +86,12 @@ pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
             assert_eq!(revert, *right.get(addr).unwrap(), "Address: {:?}", addr);
         }
     }
+
+    // The cached size accounting must match the sequential revm path. The parallel bundle path
+    // computes these independently, so a divergence means it miscounted (e.g. recording reverts
+    // without incrementing `reverts_size`).
+    assert_eq!(left.state_size, right.state_size, "state_size mismatch");
+    assert_eq!(left.reverts_size, right.reverts_size, "reverts_size mismatch");
 }
 
 pub fn compare_execution_result(left: &Vec<ExecutionResult>, right: &Vec<ExecutionResult>) {


### PR DESCRIPTION
## Problem

The parallel bundle path `BundleState::parallel_apply_transitions_and_create_reverts` (`src/storage.rs`) records per-account reverts but **never increments `BundleState::reverts_size`**, unlike the sequential revm path which does `self.reverts_size += revert.size_hint()` for every retained revert.

As a result, a bundle taken via `parallel_take_bundle(BundleRetention::Reverts)` ends up with non-empty `reverts` vectors but `reverts_size == 0`. Since `BundleState::size_hint()` is `state_size + reverts_size + contracts.len()`, the reported size **undercounts by the entire revert payload**. Any downstream logic that relies on it — size limits, memory-pressure decisions, rollback bookkeeping — can undercount attacker-sized revert data and behave unpredictably.

Tracked in Galxe/gravity-audit#661 (confirmed, P1).

## Fix

Accumulate `reverts_size` alongside the existing `state_size` counter (a per-thread `AtomicUsize` summed inside the `fork_join_util`, stored back after the loop), mirroring the sequential path. The increment is gated on `include_reverts`, matching both the sequential revm path and the existing `reverts` insertion.

## Test

Extended `compare_bundle_state` (the parallel-vs-sequential-revm bundle comparator used by every end-to-end test) to also assert the two cached size fields, `state_size` and `reverts_size`. This makes the existing suites (`native_transfers`, `erc20`, `uniswap`, `eip-7702`, `mainnet`) guard the accounting for free.

Verified the guard actually catches the bug: without the `reverts_size` fix, `native_gigagas` fails with `reverts_size mismatch — left: 47621, right: 0` (sequential reference vs parallel). With the fix, all suites pass.

Built and tested on current `main` (revm 40 / alloy-evm 0.36.0 after #108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)