### PR TITLE
feat(scheduler): opt-in deterministic skip of tx-level-invalid txns

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -28,7 +28,7 @@ use revm::{
 };
 use revm_context::{
     BlockEnv, CfgEnv, ContextSetters, ContextTr, JournalTr, TxEnv,
-    result::{EVMError, ExecutionResult, HaltReason, ResultAndState},
+    result::{EVMError, ExecutionResult, HaltReason, ResultAndState, ResultGas},
 };
 use revm_inspector::NoOpInspector;
 use revm_primitives::Address;
@@ -334,6 +334,13 @@ where
     abort: AtomicBool,
     abort_reason: OnceLock<AbortReason>,
     metrics: ExecuteMetricsCollector,
+
+    /// When true, a transaction that fails revm's tx-level validation
+    /// (`EVMError::Transaction`, e.g. `NonceTooLow`) is deterministically SKIPPED
+    /// (no state change; a phantom 0-gas revert result keeps `results` aligned 1:1 with
+    /// `txs`) instead of aborting the whole block. Off by default — existing callers are
+    /// unaffected. Opt in via [`Scheduler::with_skip_invalid_txn`]. gravity-audit#823.
+    skip_invalid_txn: bool,
 }
 
 // SAFETY: Scheduler is shared across threads via `thread::scope`. The `UnsafeCell<ParallelState>`
@@ -392,7 +399,16 @@ where
             abort: AtomicBool::new(false),
             abort_reason: OnceLock::new(),
             metrics: ExecuteMetricsCollector::default(),
+            skip_invalid_txn: false,
         }
+    }
+
+    /// Enable deterministic skipping of tx-level-invalid transactions (see the
+    /// [`Scheduler`] `skip_invalid_txn` field). Intended for order-then-execute chains
+    /// whose executor must not halt on a per-tx `InvalidTransaction`. gravity-audit#823.
+    pub fn with_skip_invalid_txn(mut self, skip: bool) -> Self {
+        self.skip_invalid_txn = skip;
+        self
     }
 
     fn async_finality(&self) {
@@ -569,8 +585,29 @@ where
         {
             let mut commiter = commiter.lock();
             // Return error if commit failed(check nonce failed)
-            if let Err(e) = commiter.commit_result() {
-                return Err(e.clone());
+            let commit_result = commiter.commit_result().clone();
+            if let Err(e) = commit_result {
+                // gravity-audit#838/#823: grevm workers run with `disable_nonce_check=true`, so a
+                // tx-level `InvalidTransaction` (e.g. `NonceTooLow` from an EIP-7702
+                // delegate-then-CREATE nonce bump) is only detected HERE at commit — the finality
+                // loop set `AbortReason::EvmError`, but this short-circuit returns before
+                // `post_execute()`'s skip path. When skipping is enabled, route it to the same
+                // deterministic sequential fallback instead of returning `Err` (which the caller
+                // turns into `panic!` → halt). Without this, the parallel path
+                // (`block_size >= MIN_PARALLEL_TXS`) bypasses the skip entirely.
+                //
+                // `commit()` applied state only for the prefix `[0, txid)` but still pushed the
+                // failing tx's result (async_commit.rs), so truncate results to `txid` to keep
+                // `self.results` aligned with committed state; `fallback_sequential` then resumes
+                // from `txid`, re-executes it against the final pre-state, and skips it.
+                if self.skip_invalid_txn && matches!(e.error, EVMError::Transaction(_)) {
+                    let mut committed = commiter.take_result();
+                    committed.truncate(e.txid);
+                    self.results.lock().extend(committed);
+                    drop(commiter);
+                    return self.fallback_sequential();
+                }
+                return Err(e);
             }
             self.results.lock().extend(commiter.take_result());
         }
@@ -590,6 +627,15 @@ where
             if let Some(abort_reason) = self.abort_reason.get() {
                 match abort_reason {
                     AbortReason::EvmError => {
+                        // gravity-audit#823: if skipping is enabled, resume sequential execution
+                        // from the finalized prefix — it deterministically SKIPS tx-level-invalid
+                        // txs (see `fallback_sequential`) and, running against the final pre-state,
+                        // also corrects any speculative false-positive (a tx that only looked
+                        // invalid against a stale read). With the flag off, keep the original
+                        // abort.
+                        if self.skip_invalid_txn {
+                            return self.fallback_sequential();
+                        }
                         let txid = self.scheduler_ctx.finality_idx();
                         let result = self.tx_results[txid].lock();
                         if let Some(result) = result.as_ref() {
@@ -646,10 +692,32 @@ where
             }
             for txid in num_commit..self.block_size {
                 let tx_env = self.txs[txid].clone();
-                let result_and_state =
-                    evm.transact_raw(tx_env).map_err(|e| GrevmError { txid, error: e.clone() })?;
-                evm.db_mut().commit(result_and_state.state);
-                sequential_results.push(result_and_state.result);
+                match evm.transact_raw(tx_env) {
+                    Ok(result_and_state) => {
+                        evm.db_mut().commit(result_and_state.state);
+                        sequential_results.push(result_and_state.result);
+                    }
+                    // gravity-audit#823: when enabled, a tx-level `InvalidTransaction` is
+                    // deterministically SKIPPED instead of halting the block. No state commit
+                    // (no nonce/balance side effect); a phantom 0-gas Revert keeps `results`
+                    // aligned 1:1 with the block's txs. Non-tx-level errors (Header/Database)
+                    // stay fatal; with the flag off this falls through to the `Err(e)` arm and
+                    // preserves the original abort behaviour.
+                    Err(EVMError::Transaction(err)) if self.skip_invalid_txn => {
+                        tracing::error!(
+                            target: "grevm",
+                            txid,
+                            ?err,
+                            "skipping tx-level-invalid tx (deterministic sequential skip)"
+                        );
+                        sequential_results.push(ExecutionResult::Revert {
+                            gas: ResultGas::new(0, 0, 0),
+                            logs: Vec::new(),
+                            output: revm_primitives::Bytes::new(),
+                        });
+                    }
+                    Err(e) => return Err(GrevmError { txid, error: e }),
+                }
                 self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
             }
         }


### PR DESCRIPTION
## What

Adds `Scheduler::with_skip_invalid_txn(bool)` (off by default). When enabled, a transaction
that fails revm's tx-level validation (`EVMError::Transaction`, e.g. `NonceTooLow`,
`RejectCallerWithCode`) is **deterministically skipped** — no state change, and a phantom
0-gas `Revert` result keeps `results` aligned 1:1 with the block's txs — instead of aborting
the whole block. Non-tx-level errors (`Header`/`Database`) stay fatal.

**Non-breaking:** the flag defaults to `false`, so existing callers are unchanged (the abort
path and `GrevmError` are preserved verbatim).

## Why

grevm is the executor for the Gravity order-then-execute L1: consensus commits an *ordered*
block whose per-tx validity cannot be fully pre-screened, because some invalidity is
**execution-induced** and unmodelable without executing — e.g. a `CREATE`/`CREATE2` run by an
EIP-7702-delegated authority bumps that account's nonce a second time, so a same-block
follow-up tx becomes `NonceTooLow` only at execution. Today any such tx makes `execute()`
return `Err`, which the caller turns into `panic!` → **whole-network halt** (gravity-audit#838).
This lets the executor skip the offending tx and keep producing blocks — the durable close-out
of that halt class (gravity-audit#823).

## Determinism (why this is safe for consensus)

The skip runs in `fallback_sequential`, i.e. **sequential execution against the final
pre-state**, so:
- the decision is not a speculative false-positive (a tx that only looked invalid against a
  stale optimistic read is re-checked against the committed pre-state); and
- because the parallel committed prefix is sequential-equivalent (Block-STM) and the sequential
  tail completes the remainder, the final `results` / state root are **identical on every node**
  regardless of where parallel execution aborted.

## Verification (single-node + 4-validator devnet, Prague)

Built into `gravity_node` and driven with the EIP-7702 authority-nonce halt pair (a
`SetCode(n)` whose authorization double-bumps the sender, plus a stale `plain(n+1)` co-located
in the same block; the pre-#385 filter admits the stale tx so it reaches the executor):

| mode | result |
|---|---|
| **flag ON** (caller opts in) | `ERROR ... skipping tx-level-invalid tx ... txid=1 err=NonceTooLow{tx:1,state:2}`; chain keeps producing (`head 174→331`), stale tx gets a phantom receipt |
| **flag OFF** (default) | node aborts on the same block — **original halt behaviour preserved** |
| **4 validators (flag ON)** | all four nodes skip and produce a **byte-identical** block (same hash) and keep advancing → deterministic, no fork |

## Caller opt-in

The caller enables it explicitly, e.g. in the reth `ParallelExecutor`:
```rust
let executor = Scheduler::new(cfg, env, txs, state, false, precompiles)
    .with_skip_invalid_txn(true);
```
That reth-side change is a separate PR and should be gated with the coordinated
state-transition-function upgrade (a bad tx goes from *halt* to *skip*; mixed versions cause a
liveness stall, not a state fork — only the skip result exists).

## Receipt semantics — resolved (gravity-audit#823)

The phantom 0-gas `Revert` (keeps `results` 1:1, commits no state) is the **intended** shape for
this path. gravity-audit#823 settled it in favor of a **deterministic status-0 revert receipt**
— every committed tx yields exactly one receipt (tooling totality) — with **no state effect**:
for a *tx-level-invalid* tx (e.g. `NonceTooLow`) the executor charges **no gas** and does **not**
bump the nonce. That is deliberately different from a normal execution *revert* (which does
charge gas / bump nonce): for a `NonceTooLow` tx the account nonce is already ahead (nothing to
advance), and charging gas for a tx that only reaches execution via a faulty proposer would be a
replay-griefing vector. Full rationale + the Monad comparison it's grounded in are in
gravity-audit#823.

So the remaining action is on the **receipt builder** (greth side, not grevm): ensure the receipt
derived from the phantom `Revert` (zero gas, empty logs, empty output — revm 40:
`ExecutionResult::Revert { gas: ResultGas::new(0,0,0), logs: vec![], output: Bytes::new() }`)
is well-formed — `status = 0`, empty
`logs`/`logsBloom`, null `contractAddress`, `cumulativeGasUsed` carried monotonically (this tx
adds 0). `output: []` (no return data) is correct.




## Update — parallel-path skip (was bypassed)

A review found the original skip only engaged on the **sequential** path. On the parallel path
(`block_size >= MIN_PARALLEL_TXS`, default 64), workers run with `disable_nonce_check=true`, so a
`NonceTooLow` is detected by the **committer**, and `parallel_execute`'s `commit_result()`
short-circuit returned `Err` **before** `post_execute()`'s skip — so the caller still `panic!`ed
→ halt. My earlier devnet test only exercised small (sequential-path) blocks and missed this.

Fixed by routing a commit-detected tx-level `EVMError::Transaction` to `fallback_sequential` too
(truncating `results` to the failing `txid` so it re-executes and skips it). Verified on both revm
versions with a 102-tx block: **skip ON → `Ok` (skip engaged); skip OFF → `Err(NonceTooLow)`
(non-breaking)**.
