### PR TITLE
feat(exec): skip recoverable invalid transactions via fallback

### DIFF
--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -248,12 +248,6 @@ fn benchmark_gigagas(c: &mut Criterion) {
     let hot_ratio = std::env::var("HOT_RATIO").map(|s| s.parse().unwrap()).unwrap_or(0.0);
     let filter: String = std::env::var("FILTER").unwrap_or_default();
     let filter: HashSet<&str> = filter.split(',').filter(|s| !s.is_empty()).collect();
-    if std::env::var("ASYNC_COMMIT_STATE").is_err() {
-        unsafe {
-            std::env::set_var("ASYNC_COMMIT_STATE", "false");
-        }
-    }
-
     if !filter.is_empty() && filter.contains("independent") {
         bench_raw_transfers(c, db_latency_us);
         bench_erc20(c, db_latency_us);

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,6 @@ and asserts both the per-transaction results and the final bundle state match.
 | `GREVM_MIN_PARALLEL_TXS` | `64` | Blocks with fewer transactions fall back to sequential. Set to `0` to force the parallel path even for tiny blocks (needed when replaying small real blocks). |
 | `GREVM_FALLBACK_SEQUENTIAL` | `false` | Force sequential execution for every block. |
 | `GREVM_CONCURRENT_LEVEL` | number of CPU cores | Worker/partition count for parallel execution. |
-| `ASYNC_COMMIT_STATE` | `true` | Asynchronously bundle execution results during parallel execution. |
 | `GREVM_MAINNET_BLOCKS` | `test_data/mainnet_blocks` | Directory the mainnet replay test reads single-block fixtures from. |
 | `GREVM_CONTINUOUS_BLOCKS` | `test_data/con_eth_blocks` | Directory the `continuous` bench reads merged "big block" fixtures from. |
 

--- a/docs/use-with-reth.md
+++ b/docs/use-with-reth.md
@@ -16,7 +16,7 @@ Grevm's public surface is small: build a [`ParallelState`] over any read-only da
 ```rust
 use std::sync::Arc;
 
-use grevm::{ParallelState, ParallelTakeBundle, Scheduler};
+use grevm::{ParallelState, ParallelTakeBundle, Scheduler, TxExecutionOutcome};
 use revm::DatabaseRef;
 use revm_context::{BlockEnv, CfgEnv, TxEnv};
 use revm_database::states::bundle_state::BundleRetention;
@@ -43,7 +43,18 @@ where
     let (results, mut state) = scheduler.take_result_and_state();
     let bundle = state.parallel_take_bundle(BundleRetention::Reverts);
 
-    // `results`: one `ExecutionResult` per transaction, in order.
+    // `results`: one outcome per transaction, in order. Recoverable invalid transactions are
+    // represented as `Skipped` and do not modify state or consume gas.
+    for outcome in &results {
+        match outcome {
+            TxExecutionOutcome::Executed(result) => {
+                let _gas_used = result.gas_used();
+            }
+            TxExecutionOutcome::Skipped(reason) => {
+                eprintln!("transaction skipped: {reason:?}");
+            }
+        }
+    }
     // `bundle`:  the `BundleState` to persist to your database.
     let _ = (results, bundle);
 }
@@ -69,7 +80,7 @@ where
     pub fn parallel_execute(&self, concurrency_level: Option<usize>)
         -> Result<(), GrevmError<DB::Error>>;
 
-    pub fn take_result_and_state(self) -> (Vec<ExecutionResult>, ParallelState<DB>);
+    pub fn take_result_and_state(self) -> (Vec<TxExecutionOutcome>, ParallelState<DB>);
 }
 
 impl<DB> ParallelState<DB> {
@@ -77,11 +88,12 @@ impl<DB> ParallelState<DB> {
 }
 ```
 
-Public items re-exported from the crate root: `Scheduler`, `ParallelState`, `ParallelCacheState`,
-`ParallelBundleState`, `ParallelTakeBundle`, `GrevmError`, `fork_join_util`.
+Public items re-exported from the crate root include `Scheduler`, `ParallelState`,
+`ParallelCacheState`, `ParallelBundleState`, `ParallelTakeBundle`, `TxExecutionOutcome`,
+`SkipReason`, `GrevmError`, and `fork_join_util`.
 
 Execution is tuned by a few environment variables (`GREVM_MIN_PARALLEL_TXS`,
-`GREVM_FALLBACK_SEQUENTIAL`, `GREVM_CONCURRENT_LEVEL`, `ASYNC_COMMIT_STATE`). See
+`GREVM_FALLBACK_SEQUENTIAL`, `GREVM_CONCURRENT_LEVEL`). See
 [Testing & Benchmarking](testing.md#environment-variable-knobs) for the full list and a working
 end-to-end harness (`src/test_utils/common/execute.rs`).
 

--- a/docs/use-with-reth.md
+++ b/docs/use-with-reth.md
@@ -43,8 +43,8 @@ where
     let (results, mut state) = scheduler.take_result_and_state();
     let bundle = state.parallel_take_bundle(BundleRetention::Reverts);
 
-    // `results`: one outcome per transaction, in order. Recoverable invalid transactions are
-    // represented as `Skipped` and do not modify state or consume gas.
+    // `results`: one outcome per transaction, in order. Transaction-validation errors are
+    // returned as `Skipped(InvalidTransaction)` and do not modify state or consume gas.
     for outcome in &results {
         match outcome {
             TxExecutionOutcome::Executed(result) => {
@@ -90,7 +90,7 @@ impl<DB> ParallelState<DB> {
 
 Public items re-exported from the crate root include `Scheduler`, `ParallelState`,
 `ParallelCacheState`, `ParallelBundleState`, `ParallelTakeBundle`, `TxExecutionOutcome`,
-`SkipReason`, `GrevmError`, and `fork_join_util`.
+`InvalidTransaction`, `GrevmError`, and `fork_join_util`.
 
 Execution is tuned by a few environment variables (`GREVM_MIN_PARALLEL_TXS`,
 `GREVM_FALLBACK_SEQUENTIAL`, `GREVM_CONCURRENT_LEVEL`). See

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -1,7 +1,7 @@
 use revm::{Database, DatabaseCommit, DatabaseRef};
 use revm_context::{
     Transaction, TxEnv,
-    result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
+    result::{EVMError, ExecutionResult, ResultAndState},
 };
 use revm_primitives::{Address, hardfork::SpecId};
 
@@ -139,13 +139,9 @@ where
                     // A non-existent account has Ethereum's default nonce of zero.
                     let expect = info.map_or(0, |info| info.nonce);
                     if tx_env.nonce == u64::MAX && expect == u64::MAX {
-                        self.commit_result = Err(GrevmError {
-                            txid,
-                            error: EVMError::Transaction(
-                                InvalidTransaction::NonceOverflowInTransaction,
-                            ),
-                        });
-                        return false;
+                        // Leave the speculative result uncommitted and let sequential execution
+                        // classify the nonce overflow as an invalid transaction skip.
+                        return true;
                     }
                     match tx_env.nonce.cmp(&expect) {
                         Ordering::Greater => {
@@ -439,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn max_nonce_is_rejected_as_overflow() {
+    fn max_nonce_requests_sequential_fallback() {
         let caller = Address::from([0xCD; 20]);
         let state = ParallelState::new(EmptyDB::default(), true, false);
         state.insert_account(caller, make_account_info(u64::MAX));
@@ -456,13 +452,8 @@ mod tests {
 
         let fallback = commit.commit(9, &tx_env, make_result_and_state(caller, u64::MAX));
 
-        assert!(!fallback, "nonce overflow is fatal, not a recoverable skip");
-        let error = commit.commit_result().as_ref().expect_err("nonce overflow must be returned");
-        assert_eq!(error.txid, 9);
-        assert!(matches!(
-            error.error,
-            EVMError::Transaction(InvalidTransaction::NonceOverflowInTransaction)
-        ));
+        assert!(fallback, "nonce overflow must be revalidated by sequential fallback");
+        assert!(commit.commit_result().is_ok());
         assert!(commit.take_result().is_empty(), "overflow transaction must not be committed");
     }
 }

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -5,7 +5,7 @@ use revm_context::{
 };
 use revm_primitives::{Address, hardfork::SpecId};
 
-use crate::{GrevmError, ParallelState, TxId};
+use crate::{GrevmError, ParallelState, TxExecutionOutcome, TxId};
 use std::{cell::UnsafeCell, cmp::Ordering};
 
 /// Only constructible within the commit thread's scope (or sequential fallback).
@@ -42,7 +42,7 @@ where
     spec: SpecId,
     /// Block base fee per gas — the burned portion that does not reach the coinbase post-LONDON.
     basefee: u64,
-    results: Vec<ExecutionResult>,
+    results: Vec<TxExecutionOutcome>,
     guard: CommitGuard<'a, DB>,
     commit_result: Result<(), GrevmError<DB::Error>>,
     disable_nonce_check: bool,
@@ -113,7 +113,7 @@ where
         }
     }
 
-    pub(crate) fn take_result(&mut self) -> Vec<ExecutionResult> {
+    pub(crate) fn take_result(&mut self) -> Vec<TxExecutionOutcome> {
         std::mem::take(&mut self.results)
     }
 
@@ -121,57 +121,58 @@ where
         &self.commit_result
     }
 
-    pub(crate) fn commit(&mut self, txid: TxId, tx_env: &TxEnv, result_and_state: ResultAndState) {
+    pub(crate) fn commit(
+        &mut self,
+        txid: TxId,
+        tx_env: &TxEnv,
+        result_and_state: ResultAndState,
+    ) -> bool {
         // During Grevm's execution, transaction nonces are temporarily set to `None` to bypass the
         // EVM's strict sequential nonce verification. This design enables concurrent transaction
         // processing without immediate validation failures. However, during the final commitment
         // phase, the system enforces strict nonce monotonicity checks to guarantee transaction
         // integrity and prevent double-spending attacks.
         let ResultAndState { result, state } = result_and_state;
+        if !self.disable_nonce_check {
+            match self.state_ref().basic_ref(tx_env.caller) {
+                Ok(info) => {
+                    // A non-existent account has Ethereum's default nonce of zero.
+                    let expect = info.map_or(0, |info| info.nonce);
+                    if tx_env.nonce == u64::MAX && expect == u64::MAX {
+                        self.commit_result = Err(GrevmError {
+                            txid,
+                            error: EVMError::Transaction(
+                                InvalidTransaction::NonceOverflowInTransaction,
+                            ),
+                        });
+                        return false;
+                    }
+                    match tx_env.nonce.cmp(&expect) {
+                        Ordering::Greater => {
+                            // Do not finalize the speculative nonce verdict here. Leave this
+                            // transaction out of `results` so sequential fallback starts at this
+                            // exact transaction and validates it again against committed state.
+                            return true;
+                        }
+                        Ordering::Less => {
+                            // See the nonce-too-high branch above: fallback owns the final outcome.
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                Err(e) => {
+                    self.commit_result = Err(GrevmError { txid, error: EVMError::Database(e) });
+                    return false;
+                }
+            }
+        }
         // Self-compute the miner reward: upstream revm credits the coinbase inside execution, which
         // grevm suppresses with a custom `Handler` (see `scheduler::NoRewardHandler`) and applies
         // here instead. This reproduces what the dropped `Galxe/revm` fork returned via
         // `ResultAndState.lazy_reward`.
         let reward = self.compute_reward(tx_env, &result);
-        if !self.disable_nonce_check {
-            match self.state_ref().basic_ref(tx_env.caller) {
-                Ok(info) => {
-                    if let Some(info) = info {
-                        let expect = info.nonce;
-                        match tx_env.nonce.cmp(&expect) {
-                            Ordering::Greater => {
-                                self.commit_result = Err(GrevmError {
-                                    txid,
-                                    error: EVMError::Transaction(
-                                        InvalidTransaction::NonceTooHigh {
-                                            tx: tx_env.nonce,
-                                            state: expect,
-                                        },
-                                    ),
-                                });
-                            }
-                            Ordering::Less => {
-                                self.commit_result = Err(GrevmError {
-                                    txid,
-                                    error: EVMError::Transaction(InvalidTransaction::NonceTooLow {
-                                        tx: tx_env.nonce,
-                                        state: expect,
-                                    }),
-                                });
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                Err(e) => {
-                    self.commit_result = Err(GrevmError { txid, error: EVMError::Database(e) })
-                }
-            }
-        }
-        self.results.push(result);
-        if self.commit_result.is_err() {
-            return;
-        }
+        self.results.push(TxExecutionOutcome::Executed(result));
         self.state_mut().commit(state);
 
         // In Ethereum, each transaction includes a miner reward, which would introduce write
@@ -182,7 +183,10 @@ where
         // will read the proper miner state from ParallelState (verified via commit_idx) without
         // creating artificial dependencies.
         let coinbase = self.coinbase;
-        assert!(self.state_mut().increment_balances(vec![(coinbase, reward)]).is_ok());
+        if let Err(error) = self.state_mut().increment_balances(vec![(coinbase, reward)]) {
+            self.commit_result = Err(GrevmError { txid, error: EVMError::Database(error) });
+        }
+        false
     }
 }
 
@@ -190,13 +194,50 @@ where
 mod tests {
     use super::*;
     use revm_context::{
+        DBErrorMarker,
         either::Either,
         result::{Output, SuccessReason},
         transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization},
     };
     use revm_database::EmptyDB;
     use revm_primitives::{Address, B256, Bytes, HashMap, U256};
-    use revm_state::{Account, AccountInfo, AccountStatus, EvmStorage};
+    use revm_state::{Account, AccountInfo, AccountStatus, Bytecode, EvmStorage};
+    use std::fmt::{Display, Formatter};
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestDbError;
+
+    impl Display for TestDbError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.write_str("test database error")
+        }
+    }
+
+    impl core::error::Error for TestDbError {}
+    impl DBErrorMarker for TestDbError {}
+
+    #[derive(Clone, Debug, Default)]
+    struct FailingDb;
+
+    impl DatabaseRef for FailingDb {
+        type Error = TestDbError;
+
+        fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Err(TestDbError)
+        }
+
+        fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Err(TestDbError)
+        }
+
+        fn storage_ref(&self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            Err(TestDbError)
+        }
+
+        fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+            Err(TestDbError)
+        }
+    }
 
     fn make_account_info(nonce: u64) -> AccountInfo {
         AccountInfo {
@@ -350,5 +391,78 @@ mod tests {
             true,
         );
         assert_eq!(post.compute_reward(&tx_env, &result), (100u128 - 10) * gas_used as u128);
+    }
+
+    #[test]
+    fn reward_database_error_is_recorded_as_commit_error() {
+        let caller = Address::from([0xCA; 20]);
+        let coinbase = Address::from([0xCB; 20]);
+        let state = ParallelState::new(FailingDb, true, false);
+        // Committing the transaction itself must not access the failing database. Only the missing
+        // coinbase account should fail when the deferred reward is applied.
+        state.insert_account(caller, make_account_info(0));
+        let state_cell = UnsafeCell::new(state);
+        let mut commit =
+            StateAsyncCommit::new(coinbase, SpecId::PRAGUE, 0, CommitGuard::new(&state_cell), true);
+        let tx_env = TxEnv { caller, gas_price: 1, gas_limit: 21_000, ..Default::default() };
+
+        commit.commit(7, &tx_env, make_result_and_state(caller, 1));
+
+        let error = commit.commit_result().as_ref().expect_err("reward DB error must be returned");
+        assert_eq!(error.txid, 7);
+        assert!(matches!(error.error, EVMError::Database(TestDbError)));
+    }
+
+    #[test]
+    fn nonce_mismatch_is_left_uncommitted_for_sequential_revalidation() {
+        let caller = Address::from([0xCC; 20]);
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        let state_cell = UnsafeCell::new(state);
+        let mut commit = StateAsyncCommit::new(
+            Address::ZERO,
+            SpecId::PRAGUE,
+            0,
+            CommitGuard::new(&state_cell),
+            false,
+        );
+        commit.init().expect("init");
+        let tx_env = TxEnv { caller, nonce: 1, ..Default::default() };
+
+        let fallback = commit.commit(0, &tx_env, make_result_and_state(caller, 1));
+
+        assert!(fallback, "nonce-too-high sender must request sequential fallback");
+        assert!(commit.commit_result().is_ok());
+        assert!(
+            commit.take_result().is_empty(),
+            "the mismatched transaction must be revalidated by sequential fallback"
+        );
+    }
+
+    #[test]
+    fn max_nonce_is_rejected_as_overflow() {
+        let caller = Address::from([0xCD; 20]);
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(caller, make_account_info(u64::MAX));
+        let state_cell = UnsafeCell::new(state);
+        let mut commit = StateAsyncCommit::new(
+            Address::ZERO,
+            SpecId::PRAGUE,
+            0,
+            CommitGuard::new(&state_cell),
+            false,
+        );
+        commit.init().expect("init");
+        let tx_env = TxEnv { caller, nonce: u64::MAX, ..Default::default() };
+
+        let fallback = commit.commit(9, &tx_env, make_result_and_state(caller, u64::MAX));
+
+        assert!(!fallback, "nonce overflow is fatal, not a recoverable skip");
+        let error = commit.commit_result().as_ref().expect_err("nonce overflow must be returned");
+        assert_eq!(error.txid, 9);
+        assert!(matches!(
+            error.error,
+            EVMError::Transaction(InvalidTransaction::NonceOverflowInTransaction)
+        ));
+        assert!(commit.take_result().is_empty(), "overflow transaction must not be committed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ mod utils;
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use lazy_static::lazy_static;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use revm_context::result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState};
+pub use revm_context::result::InvalidTransaction;
+use revm_context::result::{EVMError, ExecutionResult, ResultAndState};
 use revm_primitives::{Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode};
 use std::{cmp::min, thread};
@@ -164,44 +165,14 @@ enum AbortReason<DBError> {
     FallbackSequential,
 }
 
-/// Stable reason recorded when a transaction is skipped without changing state.
-///
-/// The numeric values are part of the consumer-facing protocol and must not be reordered.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u16)]
-pub enum SkipReason {
-    /// The transaction nonce is lower than the committed sender nonce.
-    NonceTooLow = 1,
-    /// The transaction nonce is higher than the committed sender nonce.
-    NonceTooHigh = 2,
-    /// The sender cannot cover the transaction's maximum upfront cost.
-    InsufficientFunds = 3,
-    /// The sender is rejected by EIP-3607 because it has non-delegated code.
-    SenderNotEoa = 4,
-}
-
-impl SkipReason {
-    /// Classifies the small, explicit set of transaction errors that are safe to treat as a
-    /// state-free skip. Unknown transaction errors and all non-transaction errors remain fatal.
-    pub fn from_evm_error<DBError>(error: &EVMError<DBError>) -> Option<Self> {
-        let EVMError::Transaction(error) = error else { return None };
-        match error {
-            InvalidTransaction::NonceTooLow { .. } => Some(Self::NonceTooLow),
-            InvalidTransaction::NonceTooHigh { .. } => Some(Self::NonceTooHigh),
-            InvalidTransaction::LackOfFundForMaxFee { .. } => Some(Self::InsufficientFunds),
-            InvalidTransaction::RejectCallerWithCode => Some(Self::SenderNotEoa),
-            _ => None,
-        }
-    }
-}
-
 /// Final outcome for one transaction in block order.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TxExecutionOutcome {
     /// The transaction executed normally, including EVM reverts and halts.
     Executed(ExecutionResult),
-    /// The transaction was invalid at the committed state and was applied as a no-op.
-    Skipped(SkipReason),
+    /// The transaction was invalid at the committed state and was applied as a no-op. The exact
+    /// revm validation error is forwarded to the consumer for protocol-specific encoding.
+    Skipped(InvalidTransaction),
 }
 
 /// Grevm error type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod utils;
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use lazy_static::lazy_static;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use revm_context::result::{EVMError, ResultAndState};
+use revm_context::result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState};
 use revm_primitives::{Address, B256, U256};
 use revm_state::{AccountInfo, Bytecode};
 use std::{cmp::min, thread};
@@ -146,12 +146,62 @@ impl Default for Task {
     }
 }
 
-enum AbortReason {
-    EvmError,
+enum AbortReason<DBError> {
+    /// A fatal EVM error produced while executing this transaction. The error itself remains in
+    /// `Scheduler::tx_results`.
+    FatalEvmError(TxId),
+    /// A commit error is not stored in `Scheduler::tx_results`, so the abort reason carries the
+    /// complete error instead of trying to recover it from an execution result.
+    CommitError(GrevmError<DBError>),
+    /// An invariant of the parallel scheduler was violated before the current transaction was
+    /// committed. The committed prefix is still valid, so execution can resume sequentially.
+    ParallelError {
+        txid: TxId,
+        message: &'static str,
+    },
     #[allow(dead_code)]
     SelfDestructed,
-    #[allow(dead_code)]
     FallbackSequential,
+}
+
+/// Stable reason recorded when a transaction is skipped without changing state.
+///
+/// The numeric values are part of the consumer-facing protocol and must not be reordered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum SkipReason {
+    /// The transaction nonce is lower than the committed sender nonce.
+    NonceTooLow = 1,
+    /// The transaction nonce is higher than the committed sender nonce.
+    NonceTooHigh = 2,
+    /// The sender cannot cover the transaction's maximum upfront cost.
+    InsufficientFunds = 3,
+    /// The sender is rejected by EIP-3607 because it has non-delegated code.
+    SenderNotEoa = 4,
+}
+
+impl SkipReason {
+    /// Classifies the small, explicit set of transaction errors that are safe to treat as a
+    /// state-free skip. Unknown transaction errors and all non-transaction errors remain fatal.
+    pub fn from_evm_error<DBError>(error: &EVMError<DBError>) -> Option<Self> {
+        let EVMError::Transaction(error) = error else { return None };
+        match error {
+            InvalidTransaction::NonceTooLow { .. } => Some(Self::NonceTooLow),
+            InvalidTransaction::NonceTooHigh { .. } => Some(Self::NonceTooHigh),
+            InvalidTransaction::LackOfFundForMaxFee { .. } => Some(Self::InsufficientFunds),
+            InvalidTransaction::RejectCallerWithCode => Some(Self::SenderNotEoa),
+            _ => None,
+        }
+    }
+}
+
+/// Final outcome for one transaction in block order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TxExecutionOutcome {
+    /// The transaction executed normally, including EVM reverts and halts.
+    Executed(ExecutionResult),
+    /// The transaction was invalid at the committed state and was applied as a no-op.
+    Skipped(SkipReason),
 }
 
 /// Grevm error type.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,7 +1,7 @@
 use crate::{
     AbortReason, CONCURRENT_LEVEL, FALLBACK_SEQUENTIAL, GrevmError, LocationAndType,
-    MIN_PARALLEL_TXS, MemoryEntry, ParallelState, ReadVersion, Task, TransactionResult,
-    TransactionStatus, TxId, TxState, TxVersion,
+    MIN_PARALLEL_TXS, MemoryEntry, ParallelState, ReadVersion, SkipReason, Task, TransactionResult,
+    TransactionStatus, TxExecutionOutcome, TxId, TxState, TxVersion,
     async_commit::{CommitGuard, StateAsyncCommit},
     hint::ParallelExecutionHints,
     storage::CacheDB,
@@ -28,7 +28,7 @@ use revm::{
 };
 use revm_context::{
     BlockEnv, CfgEnv, ContextSetters, ContextTr, JournalTr, TxEnv,
-    result::{EVMError, ExecutionResult, HaltReason, ResultAndState},
+    result::{EVMError, HaltReason, ResultAndState},
 };
 use revm_inspector::NoOpInspector;
 use revm_primitives::Address;
@@ -322,7 +322,7 @@ where
     block_size: usize,
     txs: Arc<Vec<TxEnv>>,
     state: UnsafeCell<ParallelState<DB>>,
-    results: Mutex<Vec<ExecutionResult>>,
+    results: Mutex<Vec<TxExecutionOutcome>>,
     tx_states: Vec<Mutex<TxState>>,
     tx_results: Vec<Mutex<Option<TransactionResult<DB::Error>>>>,
     tx_dependency: TxDependency,
@@ -332,7 +332,7 @@ where
     custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>,
 
     abort: AtomicBool,
-    abort_reason: OnceLock<AbortReason>,
+    abort_reason: OnceLock<AbortReason<DB::Error>>,
     metrics: ExecuteMetricsCollector,
 }
 
@@ -459,22 +459,43 @@ where
     fn async_commit(&self, commiter: &Mutex<StateAsyncCommit<DB>>) {
         let mut commit_idx = 0;
         let mut commiter = commiter.lock();
-        let async_commit_state =
-            std::env::var("ASYNC_COMMIT_STATE").map_or(true, |s| s.parse().unwrap_or(true));
         while !self.abort.load(Ordering::Acquire) && commit_idx < self.block_size {
             while commit_idx < self.scheduler_ctx.finality_idx.load(Ordering::Acquire) {
-                if async_commit_state {
-                    let result = self.tx_results[commit_idx].lock().take().unwrap().execute_result;
-                    let Ok(result) = result else { panic!("Commit error tx: {}", commit_idx) };
-                    let commit_start = Instant::now();
-                    commiter.commit(commit_idx, &self.txs[commit_idx], result);
-                    self.metrics
-                        .commit_time
-                        .fetch_add(commit_start.elapsed().as_nanos() as usize, Ordering::Relaxed);
-                    if commiter.commit_result().is_err() {
-                        self.abort(AbortReason::EvmError);
-                        return;
-                    }
+                let Some(tx_result) = self.tx_results[commit_idx].lock().take() else {
+                    self.abort(AbortReason::ParallelError {
+                        txid: commit_idx,
+                        message: "finalized transaction has no execution result",
+                    });
+                    return;
+                };
+                let Ok(result) = tx_result.execute_result else {
+                    // A transaction with an EVM error must never reach finality. This is a
+                    // parallel scheduler inconsistency, so replay it from the committed state
+                    // instead of trusting the speculative result.
+                    self.abort(AbortReason::ParallelError {
+                        txid: commit_idx,
+                        message: "failed transaction reached commit",
+                    });
+                    return;
+                };
+                let commit_start = Instant::now();
+                let fallback = commiter.commit(commit_idx, &self.txs[commit_idx], result);
+                self.metrics
+                    .commit_time
+                    .fetch_add(commit_start.elapsed().as_nanos() as usize, Ordering::Relaxed);
+                if let Err(error) = commiter.commit_result() {
+                    // Commit errors do not live in `tx_results`. Keep the complete error in both
+                    // `StateAsyncCommit::commit_result` and the abort reason so either
+                    // error-handling path can return the correct txid and source error.
+                    self.abort(AbortReason::CommitError(error.clone()));
+                    return;
+                }
+                if fallback {
+                    // `commit` deliberately leaves the problematic transaction uncommitted. Keep
+                    // the committed-prefix boundary at `commit_idx` so sequential fallback
+                    // revalidates this transaction before processing the suffix.
+                    self.abort(AbortReason::FallbackSequential);
+                    return;
                 }
                 self.scheduler_ctx.commit_idx.fetch_add(1, Ordering::AcqRel);
                 self.tx_dependency.commit(commit_idx);
@@ -484,8 +505,8 @@ where
         }
     }
 
-    /// Take `ExecutionResult` and `ParallelState`
-    pub fn take_result_and_state(self) -> (Vec<ExecutionResult>, ParallelState<DB>) {
+    /// Take transaction outcomes and `ParallelState`.
+    pub fn take_result_and_state(self) -> (Vec<TxExecutionOutcome>, ParallelState<DB>) {
         (self.results.into_inner(), self.state.into_inner())
     }
 
@@ -533,8 +554,9 @@ where
                         &self.scheduler_ctx.commit_idx,
                     );
                     let mut cfg = self.cfg.clone();
-                    // Disable nonce check to bypass the EVM's strict sequential nonce verification;
-                    // the nonce is re-checked when the transaction commits.
+                    // Disable nonce checks during speculative execution. The commit thread checks
+                    // the nonce against committed state; a mismatch leaves the transaction
+                    // uncommitted and triggers sequential revalidation from that transaction.
                     cfg.disable_nonce_check = true;
                     // Build the raw revm EVM (not wrapped in `EthEvm`) so we can drive a custom
                     // `Handler` that skips the miner reward — the reward is deferred and applied at
@@ -554,8 +576,8 @@ where
                     }
 
                     let mut task = self.next();
-                    while task.is_some() {
-                        task = match task.unwrap() {
+                    while let Some(current_task) = task {
+                        task = match current_task {
                             Task::Execution(tx_version) => self.execute(&mut evm, tx_version),
                             Task::Validation(tx_version) => self.validate(tx_version),
                         };
@@ -568,7 +590,8 @@ where
         });
         {
             let mut commiter = commiter.lock();
-            // Return error if commit failed(check nonce failed)
+            // Return fatal commit errors. Recoverable nonce errors request sequential fallback
+            // without populating `commit_result`.
             if let Err(e) = commiter.commit_result() {
                 return Err(e.clone());
             }
@@ -587,35 +610,68 @@ where
 
     fn post_execute(&self) -> Result<(), GrevmError<DB::Error>> {
         if self.abort.load(Ordering::Acquire) {
-            if let Some(abort_reason) = self.abort_reason.get() {
-                match abort_reason {
-                    AbortReason::EvmError => {
-                        let txid = self.scheduler_ctx.finality_idx();
-                        let result = self.tx_results[txid].lock();
-                        if let Some(result) = result.as_ref() {
-                            if let Err(e) = &result.execute_result {
-                                return Err(GrevmError { txid, error: e.clone() });
-                            }
-                        }
-                        panic!("Wrong abort transaction")
+            match self.abort_reason.get() {
+                Some(AbortReason::FatalEvmError(txid)) => {
+                    let error = self.tx_results.get(*txid).and_then(|result| {
+                        result
+                            .lock()
+                            .as_ref()
+                            .and_then(|result| result.execute_result.as_ref().err().cloned())
+                    });
+                    if let Some(error) = error {
+                        return Err(GrevmError { txid: *txid, error });
                     }
-                    // Grevm maintains full compatibility with self-destruct operations while
-                    // preserving the ability to fall back to sequential execution when necessary.
-                    // Although this code path remains theoretically unreachable in normal
-                    // operation, we deliberately retain it as a safeguard. Notably, Grevm
-                    // implements an optimized rollback mechanism - when parallel execution fails,
-                    // the system can resume sequential processing from the problematic transaction
-                    // rather than restarting the entire block. This represents a significant
-                    // optimization for rare edge cases, effectively preventing severe performance
-                    // degradation that could otherwise drastically slow down parallel execution
-                    // throughput.
-                    AbortReason::SelfDestructed | AbortReason::FallbackSequential => {
-                        return self.fallback_sequential();
-                    }
+
+                    // Losing the execution error is itself a parallel scheduler inconsistency.
+                    // The committed prefix remains authoritative, so replay the suffix.
+                    return self.fallback_after_parallel_error(
+                        *txid,
+                        "fatal execution abort has no matching transaction error",
+                    );
+                }
+                // `parallel_execute` normally returns `commit_result` before reaching this branch.
+                // Keeping the exact error here makes `post_execute` correct on its own as well.
+                Some(AbortReason::CommitError(error)) => return Err(error.clone()),
+                Some(AbortReason::ParallelError { txid, message }) => {
+                    return self.fallback_after_parallel_error(*txid, message);
+                }
+                // Grevm maintains full compatibility with self-destruct operations while
+                // preserving the ability to fall back to sequential execution when necessary.
+                // Although this code path remains theoretically unreachable in normal
+                // operation, we deliberately retain it as a safeguard. Notably, Grevm
+                // implements an optimized rollback mechanism - when parallel execution fails,
+                // the system can resume sequential processing from the problematic transaction
+                // rather than restarting the entire block. This represents a significant
+                // optimization for rare edge cases, effectively preventing severe performance
+                // degradation that could otherwise drastically slow down parallel execution
+                // throughput.
+                Some(AbortReason::SelfDestructed | AbortReason::FallbackSequential) => {
+                    return self.fallback_sequential();
+                }
+                None => {
+                    return self.fallback_after_parallel_error(
+                        self.scheduler_ctx.commit_idx.load(Ordering::Acquire),
+                        "parallel execution aborted without a reason",
+                    );
                 }
             }
         }
         Ok(())
+    }
+
+    fn fallback_after_parallel_error(
+        &self,
+        txid: TxId,
+        message: &str,
+    ) -> Result<(), GrevmError<DB::Error>> {
+        tracing::error!(
+            target: "grevm::scheduler",
+            block_number = %self.env.number,
+            txid,
+            reason = message,
+            "parallel execution invariant failed; falling back to sequential execution",
+        );
+        self.fallback_sequential()
     }
 
     /// Fallback to sequential execution
@@ -645,11 +701,27 @@ where
                 evm.precompiles_mut().apply_precompile(&address, move |_| Some(precompile_clone));
             }
             for txid in num_commit..self.block_size {
-                let tx_env = self.txs[txid].clone();
-                let result_and_state =
-                    evm.transact_raw(tx_env).map_err(|e| GrevmError { txid, error: e.clone() })?;
+                let result_and_state = match evm.transact_raw(self.txs[txid].clone()) {
+                    Ok(result_and_state) => result_and_state,
+                    Err(error) => {
+                        if let Some(reason) = SkipReason::from_evm_error(&error) {
+                            sequential_results.push(TxExecutionOutcome::Skipped(reason));
+                            tracing::warn!(
+                                target: "grevm::scheduler",
+                                block_number = %self.env.number,
+                                txid,
+                                ?reason,
+                                "skipping invalid transaction during sequential fallback",
+                            );
+                            self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        }
+                        return Err(GrevmError { txid, error: error.clone() });
+                    }
+                };
+
                 evm.db_mut().commit(result_and_state.state);
-                sequential_results.push(result_and_state.result);
+                sequential_results.push(TxExecutionOutcome::Executed(result_and_state.result));
                 self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
             }
         }
@@ -657,7 +729,7 @@ where
         Ok(())
     }
 
-    fn abort(&self, abort_reason: AbortReason) {
+    fn abort(&self, abort_reason: AbortReason<DB::Error>) {
         self.abort_reason.get_or_init(|| abort_reason);
         self.abort.store(true, Ordering::Release);
     }
@@ -675,7 +747,11 @@ where
             return None;
         }
         if tx_state.incarnation != incarnation {
-            panic!("Inconsistent incarnation when execution");
+            self.abort(AbortReason::ParallelError {
+                txid,
+                message: "inconsistent incarnation during execution",
+            });
+            return None;
         }
         self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
 
@@ -774,6 +850,7 @@ where
                 });
             }
             Err(e) => {
+                let recoverable = SkipReason::from_evm_error(&e).is_some();
                 conflict = true;
                 self.metrics.conflict_cnt.fetch_add(1, Ordering::Relaxed);
                 self.metrics.conflict_by_error.fetch_add(1, Ordering::Relaxed);
@@ -790,7 +867,11 @@ where
                     execute_result: Err(e),
                 });
                 if commit_idx == txid {
-                    self.abort(AbortReason::EvmError);
+                    if recoverable {
+                        self.abort(AbortReason::FallbackSequential);
+                    } else {
+                        self.abort(AbortReason::FatalEvmError(txid));
+                    }
                 }
                 self.tx_dependency.key_tx(txid, &self.scheduler_ctx.commit_idx);
             }
@@ -826,14 +907,26 @@ where
             return None;
         }
         if tx_state.incarnation != incarnation {
-            panic!("Inconsistent incarnation when validating");
+            self.abort(AbortReason::ParallelError {
+                txid,
+                message: "inconsistent incarnation during validation",
+            });
+            return None;
         }
         self.metrics.validation_cnt.fetch_add(1, Ordering::Relaxed);
         let Some(result) = tx_result.as_ref() else {
-            panic!("No result when validating");
+            self.abort(AbortReason::ParallelError {
+                txid,
+                message: "transaction has no result during validation",
+            });
+            return None;
         };
-        if let Err(_) = &result.execute_result {
-            panic!("Error transaction should take as conflict before validating");
+        if result.execute_result.is_err() {
+            self.abort(AbortReason::ParallelError {
+                txid,
+                message: "failed transaction reached validation",
+            });
+            return None;
         }
 
         let ts = self.scheduler_ctx.logical_timestamp();
@@ -968,5 +1061,99 @@ where
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm_database::EmptyDB;
+    use revm_primitives::{TxKind, U256, hardfork::SpecId};
+    use revm_state::AccountInfo;
+
+    fn empty_scheduler(num_txs: usize) -> Scheduler<EmptyDB> {
+        Scheduler::new(
+            CfgEnv::new_with_spec(SpecId::SHANGHAI),
+            BlockEnv::default(),
+            Arc::new(vec![TxEnv::default(); num_txs]),
+            ParallelState::new(EmptyDB::default(), true, false),
+            false,
+            None,
+        )
+    }
+
+    #[test]
+    fn fatal_execution_abort_uses_recorded_txid_not_finality_idx() {
+        let scheduler = empty_scheduler(3);
+        *scheduler.tx_results[2].lock() = Some(TransactionResult {
+            read_set: Default::default(),
+            write_set: Default::default(),
+            execute_result: Err(EVMError::Custom("fatal execution error".to_owned())),
+        });
+        scheduler.abort(AbortReason::FatalEvmError(2));
+
+        let error = scheduler.post_execute().expect_err("fatal abort must be returned");
+        assert_eq!(scheduler.scheduler_ctx.finality_idx(), 0);
+        assert_eq!(error.txid, 2);
+        assert!(matches!(
+            error.error,
+            EVMError::Custom(message) if message == "fatal execution error"
+        ));
+    }
+
+    #[test]
+    fn commit_abort_carries_error_without_using_tx_results() {
+        let scheduler = empty_scheduler(3);
+        scheduler.abort(AbortReason::CommitError(GrevmError {
+            txid: 1,
+            error: EVMError::Custom("commit error".to_owned()),
+        }));
+
+        let error = scheduler.post_execute().expect_err("commit abort must be returned");
+        assert_eq!(error.txid, 1);
+        assert!(matches!(
+            error.error,
+            EVMError::Custom(message) if message == "commit error"
+        ));
+        assert!(scheduler.tx_results.iter().all(|result| result.lock().is_none()));
+    }
+
+    #[test]
+    fn parallel_error_replays_suffix_from_committed_prefix() {
+        let caller = Address::from([0xCA; 20]);
+        let receiver = Address::from([0xCB; 20]);
+        let state = ParallelState::new(EmptyDB::default(), true, false);
+        state.insert_account(
+            caller,
+            AccountInfo { balance: U256::from(1_000_000), nonce: 1, ..Default::default() },
+        );
+        let suffix_tx = TxEnv {
+            caller,
+            gas_limit: 21_000,
+            kind: TxKind::Call(receiver),
+            value: U256::from(1),
+            nonce: 1,
+            ..Default::default()
+        };
+        let scheduler = Scheduler::new(
+            CfgEnv::new_with_spec(SpecId::SHANGHAI),
+            BlockEnv::default(),
+            Arc::new(vec![TxEnv::default(), suffix_tx]),
+            state,
+            false,
+            None,
+        );
+        // Model one already committed transaction. Fallback must preserve this prefix and start
+        // from tx 1 against its committed post-state.
+        scheduler.results.lock().push(TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+        scheduler.abort(AbortReason::ParallelError {
+            txid: 1,
+            message: "test parallel invariant failure",
+        });
+
+        scheduler.post_execute().expect("sequential suffix replay must succeed");
+        let results = scheduler.results.lock();
+        assert_eq!(results.len(), 2);
+        assert!(matches!(results[1], TxExecutionOutcome::Executed(_)));
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,6 @@
 use crate::{
     AbortReason, CONCURRENT_LEVEL, FALLBACK_SEQUENTIAL, GrevmError, LocationAndType,
-    MIN_PARALLEL_TXS, MemoryEntry, ParallelState, ReadVersion, SkipReason, Task, TransactionResult,
+    MIN_PARALLEL_TXS, MemoryEntry, ParallelState, ReadVersion, Task, TransactionResult,
     TransactionStatus, TxExecutionOutcome, TxId, TxState, TxVersion,
     async_commit::{CommitGuard, StateAsyncCommit},
     hint::ParallelExecutionHints,
@@ -590,8 +590,8 @@ where
         });
         {
             let mut commiter = commiter.lock();
-            // Return fatal commit errors. Recoverable nonce errors request sequential fallback
-            // without populating `commit_result`.
+            // Return fatal commit errors. Transaction-validation issues discovered while
+            // committing request sequential fallback without populating `commit_result`.
             if let Err(e) = commiter.commit_result() {
                 return Err(e.clone());
             }
@@ -701,23 +701,43 @@ where
                 evm.precompiles_mut().apply_precompile(&address, move |_| Some(precompile_clone));
             }
             for txid in num_commit..self.block_size {
+                let tx = &self.txs[txid];
+                if !self.cfg.disable_nonce_check && tx.nonce == u64::MAX {
+                    let state_nonce = match evm.db_mut().basic_ref(tx.caller) {
+                        Ok(info) => info.map_or(0, |info| info.nonce),
+                        Err(error) => {
+                            return Err(GrevmError { txid, error: EVMError::Database(error) });
+                        }
+                    };
+                    if state_nonce == u64::MAX {
+                        let error = crate::InvalidTransaction::NonceOverflowInTransaction;
+                        tracing::warn!(
+                            target: "grevm::scheduler",
+                            block_number = %self.env.number,
+                            txid,
+                            ?error,
+                            "skipping invalid transaction during sequential fallback",
+                        );
+                        sequential_results.push(TxExecutionOutcome::Skipped(error));
+                        self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                }
                 let result_and_state = match evm.transact_raw(self.txs[txid].clone()) {
                     Ok(result_and_state) => result_and_state,
-                    Err(error) => {
-                        if let Some(reason) = SkipReason::from_evm_error(&error) {
-                            sequential_results.push(TxExecutionOutcome::Skipped(reason));
-                            tracing::warn!(
-                                target: "grevm::scheduler",
-                                block_number = %self.env.number,
-                                txid,
-                                ?reason,
-                                "skipping invalid transaction during sequential fallback",
-                            );
-                            self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
-                            continue;
-                        }
-                        return Err(GrevmError { txid, error: error.clone() });
+                    Err(EVMError::Transaction(error)) => {
+                        tracing::warn!(
+                            target: "grevm::scheduler",
+                            block_number = %self.env.number,
+                            txid,
+                            ?error,
+                            "skipping invalid transaction during sequential fallback",
+                        );
+                        sequential_results.push(TxExecutionOutcome::Skipped(error));
+                        self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
+                        continue;
                     }
+                    Err(error) => return Err(GrevmError { txid, error }),
                 };
 
                 evm.db_mut().commit(result_and_state.state);
@@ -850,7 +870,7 @@ where
                 });
             }
             Err(e) => {
-                let recoverable = SkipReason::from_evm_error(&e).is_some();
+                let invalid_transaction = matches!(e, EVMError::Transaction(_));
                 conflict = true;
                 self.metrics.conflict_cnt.fetch_add(1, Ordering::Relaxed);
                 self.metrics.conflict_by_error.fetch_add(1, Ordering::Relaxed);
@@ -867,7 +887,7 @@ where
                     execute_result: Err(e),
                 });
                 if commit_idx == txid {
-                    if recoverable {
+                    if invalid_transaction {
                         self.abort(AbortReason::FallbackSequential);
                     } else {
                         self.abort(AbortReason::FatalEvmError(txid));
@@ -1145,7 +1165,9 @@ mod tests {
         );
         // Model one already committed transaction. Fallback must preserve this prefix and start
         // from tx 1 against its committed post-state.
-        scheduler.results.lock().push(TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+        scheduler.results.lock().push(TxExecutionOutcome::Skipped(
+            crate::InvalidTransaction::NonceTooLow { tx: 0, state: 1 },
+        ));
         scheduler.abort(AbortReason::ParallelError {
             txid: 1,
             message: "test parallel invariant failure",

--- a/src/test_utils/common/execute.rs
+++ b/src/test_utils/common/execute.rs
@@ -1,9 +1,10 @@
 use alloy_evm::{EthEvm, Evm, precompiles::PrecompilesMap};
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 
-use crate::{ParallelState, ParallelTakeBundle, Scheduler};
+use crate::{ParallelState, ParallelTakeBundle, Scheduler, SkipReason, TxExecutionOutcome};
 use revm::{
-    Context, DatabaseCommit, DatabaseRef, MainBuilder, MainContext, handler::EthPrecompiles,
+    Context, DatabaseCommit, DatabaseRef, MainBuilder, MainContext,
+    precompile::{PrecompileSpecId, Precompiles},
 };
 use revm_context::{
     BlockEnv, CfgEnv, TxEnv,
@@ -94,8 +95,11 @@ pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
     assert_eq!(left.reverts_size, right.reverts_size, "reverts_size mismatch");
 }
 
-pub fn compare_execution_result(left: &Vec<ExecutionResult>, right: &Vec<ExecutionResult>) {
+pub fn compare_execution_result(left: &Vec<ExecutionResult>, right: &Vec<TxExecutionOutcome>) {
     for (i, (left_res, right_res)) in left.iter().zip(right.iter()).enumerate() {
+        let TxExecutionOutcome::Executed(right_res) = right_res else {
+            panic!("valid reference transaction {i} was unexpectedly skipped: {right_res:?}");
+        };
         assert_eq!(left_res, right_res, "Tx {}", i);
     }
     assert_eq!(left.len(), right.len());
@@ -143,6 +147,43 @@ pub fn compare_evm_execute_with_spec<DB>(
         ReplayOutcome::Ok { .. } => {}
         ReplayOutcome::SequentialFailed(e) => panic!("sequential reference execution failed: {e}"),
     }
+}
+
+/// Compare Grevm against an independent, strictly ordered revm execution that skips only the
+/// explicitly supported recoverable transaction errors.
+///
+/// Both per-transaction outcomes and the complete post-block bundle state are compared. This is
+/// the reference path for testing Grevm's sequential fallback with blocks that intentionally
+/// contain invalid transactions.
+pub fn compare_evm_execute_skipping_invalid_with_spec<DB>(
+    db: DB,
+    txs: Vec<TxEnv>,
+    with_hints: bool,
+    spec: SpecId,
+) -> Vec<TxExecutionOutcome>
+where
+    DB: DatabaseRef + Send + Sync + Debug,
+    DB::Error: Send + Sync + Clone + Debug + 'static,
+{
+    let db = Arc::new(db);
+    let txs = Arc::new(txs);
+    let cfg = CfgEnv::new_with_spec(spec);
+    let mut env = BlockEnv::default();
+    env.beneficiary = super::account::MINER_ADDRESS;
+
+    let (expected_outcomes, expected_bundle) =
+        execute_revm_sequential_skipping_invalid(db.clone(), cfg.clone(), env.clone(), &txs)
+            .unwrap_or_else(|error| panic!("sequential skip reference failed: {error:?}"));
+
+    let state = ParallelState::new(db, true, true);
+    let scheduler = Scheduler::new(cfg, env, txs, state, with_hints, None);
+    scheduler.parallel_execute(Some(23)).expect("parallel execute failed");
+    let (actual_outcomes, mut state) = scheduler.take_result_and_state();
+    let actual_bundle = state.parallel_take_bundle(BundleRetention::Reverts);
+
+    assert_eq!(expected_outcomes, actual_outcomes, "transaction outcomes differ");
+    compare_bundle_state(&expected_bundle, &actual_bundle);
+    actual_outcomes
 }
 
 /// Outcome of a parallel-vs-sequential comparison.
@@ -237,13 +278,16 @@ where
     DB: DatabaseRef + Debug,
     DB::Error: Send + Sync + Debug + 'static,
 {
+    let spec = cfg.spec;
     let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
     let evm = Context::mainnet()
         .with_db(db)
         .with_cfg(cfg)
         .with_block(env)
         .build_mainnet_with_inspector(NoOpInspector {})
-        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+        .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
+            PrecompileSpecId::from_spec_id(spec),
+        )));
     let mut evm = EthEvm::new(evm, false);
 
     let mut results = Vec::with_capacity(txs.len());
@@ -255,6 +299,51 @@ where
     evm.db_mut().merge_transitions(BundleRetention::Reverts);
 
     Ok((results, evm.db_mut().take_bundle()))
+}
+
+/// Execute every transaction strictly in block order, committing successful EVM executions and
+/// treating only known recoverable transaction-validation errors as state-free skips.
+///
+/// Unknown transaction errors, database errors, custom errors, and header errors remain fatal so
+/// this reference cannot accidentally hide a consensus or database failure.
+pub fn execute_revm_sequential_skipping_invalid<DB>(
+    db: DB,
+    cfg: CfgEnv,
+    env: BlockEnv,
+    txs: &[TxEnv],
+) -> Result<(Vec<TxExecutionOutcome>, BundleState), EVMError<DB::Error>>
+where
+    DB: DatabaseRef + Debug,
+    DB::Error: Send + Sync + Debug + 'static,
+{
+    let spec = cfg.spec;
+    let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
+    let evm = Context::mainnet()
+        .with_db(db)
+        .with_cfg(cfg)
+        .with_block(env)
+        .build_mainnet_with_inspector(NoOpInspector {})
+        .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
+            PrecompileSpecId::from_spec_id(spec),
+        )));
+    let mut evm = EthEvm::new(evm, false);
+
+    let mut outcomes = Vec::with_capacity(txs.len());
+    for tx in txs {
+        match evm.transact_raw(tx.clone()) {
+            Ok(result_and_state) => {
+                evm.db_mut().commit(result_and_state.state);
+                outcomes.push(TxExecutionOutcome::Executed(result_and_state.result));
+            }
+            Err(error) => match SkipReason::from_evm_error(&error) {
+                Some(reason) => outcomes.push(TxExecutionOutcome::Skipped(reason)),
+                None => return Err(error),
+            },
+        }
+    }
+    evm.db_mut().merge_transitions(BundleRetention::Reverts);
+
+    Ok((outcomes, evm.db_mut().take_bundle()))
 }
 
 /// Sequentially execute `txs` against `db` under `cfg`/`env`, returning the indices of the
@@ -278,13 +367,16 @@ where
     DB: DatabaseRef + Debug,
     DB::Error: Send + Sync + Debug + 'static,
 {
+    let spec = cfg.spec;
     let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
     let evm = Context::mainnet()
         .with_db(db)
         .with_cfg(cfg)
         .with_block(env)
         .build_mainnet_with_inspector(NoOpInspector {})
-        .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+        .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
+            PrecompileSpecId::from_spec_id(spec),
+        )));
     let mut evm = EthEvm::new(evm, false);
 
     let mut kept = Vec::new();

--- a/src/test_utils/common/execute.rs
+++ b/src/test_utils/common/execute.rs
@@ -1,7 +1,7 @@
 use alloy_evm::{EthEvm, Evm, precompiles::PrecompilesMap};
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 
-use crate::{ParallelState, ParallelTakeBundle, Scheduler, SkipReason, TxExecutionOutcome};
+use crate::{ParallelState, ParallelTakeBundle, Scheduler, TxExecutionOutcome};
 use revm::{
     Context, DatabaseCommit, DatabaseRef, MainBuilder, MainContext,
     precompile::{PrecompileSpecId, Precompiles},
@@ -149,8 +149,8 @@ pub fn compare_evm_execute_with_spec<DB>(
     }
 }
 
-/// Compare Grevm against an independent, strictly ordered revm execution that skips only the
-/// explicitly supported recoverable transaction errors.
+/// Compare Grevm against an independent, strictly ordered revm execution that skips every
+/// transaction-validation error.
 ///
 /// Both per-transaction outcomes and the complete post-block bundle state are compared. This is
 /// the reference path for testing Grevm's sequential fallback with blocks that intentionally
@@ -302,10 +302,10 @@ where
 }
 
 /// Execute every transaction strictly in block order, committing successful EVM executions and
-/// treating only known recoverable transaction-validation errors as state-free skips.
+/// treating every transaction-validation error as a state-free skip.
 ///
-/// Unknown transaction errors, database errors, custom errors, and header errors remain fatal so
-/// this reference cannot accidentally hide a consensus or database failure.
+/// Database errors, custom errors, and header errors remain fatal so this reference cannot
+/// accidentally hide a consensus or database failure.
 pub fn execute_revm_sequential_skipping_invalid<DB>(
     db: DB,
     cfg: CfgEnv,
@@ -317,6 +317,7 @@ where
     DB::Error: Send + Sync + Debug + 'static,
 {
     let spec = cfg.spec;
+    let disable_nonce_check = cfg.disable_nonce_check;
     let db = StateBuilder::new().with_bundle_update().with_database_ref(db).build();
     let evm = Context::mainnet()
         .with_db(db)
@@ -330,15 +331,27 @@ where
 
     let mut outcomes = Vec::with_capacity(txs.len());
     for tx in txs {
+        if !disable_nonce_check && tx.nonce == u64::MAX {
+            let state_nonce = match evm.db_mut().basic_ref(tx.caller) {
+                Ok(info) => info.map_or(0, |info| info.nonce),
+                Err(error) => return Err(EVMError::Database(error)),
+            };
+            if state_nonce == u64::MAX {
+                outcomes.push(TxExecutionOutcome::Skipped(
+                    crate::InvalidTransaction::NonceOverflowInTransaction,
+                ));
+                continue;
+            }
+        }
         match evm.transact_raw(tx.clone()) {
             Ok(result_and_state) => {
                 evm.db_mut().commit(result_and_state.state);
                 outcomes.push(TxExecutionOutcome::Executed(result_and_state.result));
             }
-            Err(error) => match SkipReason::from_evm_error(&error) {
-                Some(reason) => outcomes.push(TxExecutionOutcome::Skipped(reason)),
-                None => return Err(error),
-            },
+            Err(EVMError::Transaction(error)) => {
+                outcomes.push(TxExecutionOutcome::Skipped(error));
+            }
+            Err(error) => return Err(error),
         }
     }
     evm.db_mut().merge_transitions(BundleRetention::Reverts);

--- a/tests/eip-7702.rs
+++ b/tests/eip-7702.rs
@@ -25,10 +25,17 @@
 //!   storage (Shanghai; the original `new_ca` purpose — the create side of the same coin)
 //! - [`create2_target_redelegate_and_selfdestruct`] — CREATE2 + EIP-7702 re-delegation +
 //!   self-destruct composed in one Prague block
+//! - [`delegated_create_makes_following_nonce_invalid`] — an authorization plus delegated CREATE
+//!   advances the authority nonce twice; the stale follow-up nonce is skipped
+//! - [`delegated_balance_drain_makes_following_tx_invalid`] — delegated execution drains the
+//!   authority balance; its otherwise valid follow-up transaction is skipped
 
-use grevm::test_utils::{
-    TRANSFER_GAS_LIMIT,
-    common::{account, execute, storage::InMemoryDB},
+use grevm::{
+    SkipReason, TxExecutionOutcome,
+    test_utils::{
+        TRANSFER_GAS_LIMIT,
+        common::{account, execute, storage::InMemoryDB},
+    },
 };
 use revm_context::{
     TxEnv,
@@ -172,6 +179,45 @@ fn call_tx(caller_idx: usize, to: Address) -> TxEnv {
     }
 }
 
+/// Build a sponsored type-4 transaction that both installs `authority`'s delegation and calls
+/// the authority in the same transaction. The delegated target therefore executes immediately in
+/// the authority's context.
+fn delegate_and_call_tx(
+    sponsor_idx: usize,
+    authority: Address,
+    target: Address,
+    authority_nonce: u64,
+) -> TxEnv {
+    let mut tx = delegate_tx(sponsor_idx, &[(authority, target, authority_nonce)]);
+    tx.kind = TxKind::Call(authority);
+    tx
+}
+
+fn authority_tx(authority: Address, nonce: u64, to: Address) -> TxEnv {
+    TxEnv {
+        caller: authority,
+        kind: TxKind::Call(to),
+        value: U256::ZERO,
+        gas_limit: TRANSFER_GAS_LIMIT,
+        gas_price: 1,
+        nonce,
+        ..TxEnv::default()
+    }
+}
+
+/// Execute a Prague block with sender nonce validation enabled, compare Grevm's outcomes and final
+/// state against the strictly sequential skip reference, and return the verified outcomes.
+fn execute_skip_outcomes(db: InMemoryDB, txs: Vec<TxEnv>) -> Vec<TxExecutionOutcome> {
+    execute::compare_evm_execute_skipping_invalid_with_spec(db, txs, false, SpecId::PRAGUE)
+}
+
+fn db_with_delegate_target(target: Address, code: Bytecode) -> InMemoryDB {
+    let mut db = build_db();
+    db.accounts.insert(target, contract_account(&code));
+    db.bytecodes.insert(code.hash_slow(), code);
+    db
+}
+
 fn run(txs: Vec<TxEnv>) {
     run_with_db(build_db(), txs);
 }
@@ -188,6 +234,57 @@ fn run_with_db(db: InMemoryDB, txs: Vec<TxEnv>) {
         Default::default(),
         SpecId::PRAGUE,
     );
+}
+
+/// The authorization increments A's nonce from 0 to 1, then the delegated code executes CREATE
+/// in A's context and increments it again to 2. A transaction built with the stale nonce 1 must be
+/// skipped, while the following transaction with nonce 2 must still execute.
+#[test]
+fn delegated_create_makes_following_nonce_invalid() {
+    let create_target = target_x();
+    // PUSH1 0; PUSH1 0; PUSH1 0; CREATE; POP; STOP
+    let create_code =
+        Bytecode::new_raw(vec![0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x50, 0x00].into());
+    let db = db_with_delegate_target(create_target, create_code);
+
+    let mut txs: Vec<TxEnv> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegate_and_call_tx(10, authority_a(), create_target, 0);
+    txs[11] = authority_tx(authority_a(), 1, authority_b());
+    txs[12] = authority_tx(authority_a(), 2, authority_b());
+
+    let outcomes = execute_skip_outcomes(db, txs);
+    assert_eq!(outcomes.len(), BLOCK_SIZE);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(_)));
+    assert_eq!(outcomes[11], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(outcomes[12], TxExecutionOutcome::Executed(_)));
+}
+
+/// The sponsored type-4 transaction installs A's delegation and immediately executes it in A's
+/// context. SELFDESTRUCT transfers A's entire balance to B under Prague rules. A's next
+/// nonce-correct transaction can no longer pay its intrinsic gas and must be skipped; an
+/// independent suffix transaction must still execute after the sequential fallback.
+#[test]
+fn delegated_balance_drain_makes_following_tx_invalid() {
+    let drain_target = target_x();
+    // PUSH20 B; SELFDESTRUCT
+    let mut raw_code = vec![0x73];
+    raw_code.extend_from_slice(authority_b().as_slice());
+    raw_code.push(0xff);
+    let drain_code = Bytecode::new_raw(raw_code.into());
+    let db = db_with_delegate_target(drain_target, drain_code);
+
+    let mut txs: Vec<TxEnv> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegate_and_call_tx(10, authority_a(), drain_target, 0);
+    txs[11] = authority_tx(authority_a(), 1, authority_b());
+    // Keep an independent transaction immediately after the invalid one to prove execution
+    // resumes and the block suffix is retained.
+    txs[12] = padding_tx(12);
+
+    let outcomes = execute_skip_outcomes(db, txs);
+    assert_eq!(outcomes.len(), BLOCK_SIZE);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(_)));
+    assert_eq!(outcomes[11], TxExecutionOutcome::Skipped(SkipReason::InsufficientFunds));
+    assert!(matches!(outcomes[12], TxExecutionOutcome::Executed(_)));
 }
 
 /// Positive control: a single delegation followed by a CALL. Exercises the whole 7702

--- a/tests/eip-7702.rs
+++ b/tests/eip-7702.rs
@@ -31,7 +31,7 @@
 //!   authority balance; its otherwise valid follow-up transaction is skipped
 
 use grevm::{
-    SkipReason, TxExecutionOutcome,
+    InvalidTransaction, TxExecutionOutcome,
     test_utils::{
         TRANSFER_GAS_LIMIT,
         common::{account, execute, storage::InMemoryDB},
@@ -255,7 +255,10 @@ fn delegated_create_makes_following_nonce_invalid() {
     let outcomes = execute_skip_outcomes(db, txs);
     assert_eq!(outcomes.len(), BLOCK_SIZE);
     assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(_)));
-    assert_eq!(outcomes[11], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(
+        outcomes[11],
+        TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooLow { .. })
+    ));
     assert!(matches!(outcomes[12], TxExecutionOutcome::Executed(_)));
 }
 
@@ -283,7 +286,10 @@ fn delegated_balance_drain_makes_following_tx_invalid() {
     let outcomes = execute_skip_outcomes(db, txs);
     assert_eq!(outcomes.len(), BLOCK_SIZE);
     assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(_)));
-    assert_eq!(outcomes[11], TxExecutionOutcome::Skipped(SkipReason::InsufficientFunds));
+    assert!(matches!(
+        outcomes[11],
+        TxExecutionOutcome::Skipped(InvalidTransaction::LackOfFundForMaxFee { .. })
+    ));
     assert!(matches!(outcomes[12], TxExecutionOutcome::Executed(_)));
 }
 

--- a/tests/native_transfers.rs
+++ b/tests/native_transfers.rs
@@ -1,16 +1,13 @@
 #![allow(missing_docs)]
 
 use grevm::{
-    ParallelState, Scheduler, SkipReason, TxExecutionOutcome,
+    InvalidTransaction, ParallelState, Scheduler, TxExecutionOutcome,
     test_utils::{
         TRANSFER_GAS_LIMIT,
         common::{account, execute, storage::InMemoryDB},
     },
 };
-use revm_context::{
-    BlockEnv, CfgEnv, TxEnv,
-    result::{EVMError, InvalidTransaction},
-};
+use revm_context::{BlockEnv, CfgEnv, TxEnv};
 use revm_primitives::{HashMap, TxKind, U256, hardfork::SpecId};
 use revm_state::Bytecode;
 use std::sync::Arc;
@@ -70,7 +67,10 @@ fn nonce_error_falls_back_and_skips_without_incrementing_nonce() {
     let outcomes = execute_outcomes(txs);
     assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
     assert!(matches!(outcomes[0], TxExecutionOutcome::Executed(_)));
-    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(
+        outcomes[1],
+        TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooLow { .. })
+    ));
     assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
 }
 
@@ -91,8 +91,14 @@ fn consecutive_nonce_errors_are_revalidated_and_suffix_executes() {
 
     let outcomes = execute_outcomes(txs);
     assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
-    assert_eq!(outcomes[0], TxExecutionOutcome::Skipped(SkipReason::NonceTooHigh));
-    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(
+        outcomes[0],
+        TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooHigh { .. })
+    ));
+    assert!(matches!(
+        outcomes[1],
+        TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooLow { .. })
+    ));
     assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
 }
 
@@ -114,12 +120,12 @@ fn sender_with_code_is_skipped_and_suffix_executes() {
 
     let outcomes = execute_outcomes_with_db(db, txs);
     assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
-    assert_eq!(outcomes[0], TxExecutionOutcome::Skipped(SkipReason::SenderNotEoa));
+    assert_eq!(outcomes[0], TxExecutionOutcome::Skipped(InvalidTransaction::RejectCallerWithCode));
     assert!(matches!(outcomes[1], TxExecutionOutcome::Executed(_)));
 }
 
 #[test]
-fn nonrecoverable_invalid_transaction_remains_fatal() {
+fn intrinsic_gas_error_falls_back_and_continues_suffix() {
     let accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
     let db = Arc::new(InMemoryDB::new(accounts, Default::default(), Default::default()));
     let mut invalid = independent_transfer(0);
@@ -136,15 +142,76 @@ fn nonrecoverable_invalid_transaction_remains_fatal() {
         false,
         None,
     );
-    let error = scheduler
-        .parallel_execute(Some(23))
-        .expect_err("nonrecoverable invalid transaction must abort the block");
+    scheduler.parallel_execute(Some(23)).expect("transaction validation errors must be skipped");
+    let (outcomes, _) = scheduler.take_result_and_state();
 
-    assert_eq!(error.txid, 0);
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
     assert!(matches!(
-        error.error,
-        EVMError::Transaction(InvalidTransaction::CallGasCostMoreThanGasLimit { .. })
+        outcomes[0],
+        TxExecutionOutcome::Skipped(InvalidTransaction::CallGasCostMoreThanGasLimit { .. })
     ));
+    assert!(matches!(outcomes[1], TxExecutionOutcome::Executed(_)));
+}
+
+#[test]
+fn basefee_error_falls_back_and_continues_suffix() {
+    let accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
+    let db = Arc::new(InMemoryDB::new(accounts, Default::default(), Default::default()));
+    let mut txs: Vec<_> = (0..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer).collect();
+    for tx in &mut txs {
+        tx.gas_price = 100;
+    }
+    txs[0].gas_price = 50;
+
+    let state = ParallelState::new(db, true, false);
+    let mut env = BlockEnv::default();
+    env.basefee = 100;
+    let scheduler = Scheduler::new(
+        CfgEnv::new_with_spec(SpecId::SHANGHAI),
+        env,
+        Arc::new(txs),
+        state,
+        false,
+        None,
+    );
+    scheduler.parallel_execute(Some(23)).expect("basefee-invalid transaction must be skipped");
+    let (outcomes, _) = scheduler.take_result_and_state();
+
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert_eq!(
+        outcomes[0],
+        TxExecutionOutcome::Skipped(InvalidTransaction::GasPriceLessThanBasefee)
+    );
+    assert!(matches!(outcomes[1], TxExecutionOutcome::Executed(_)));
+}
+
+#[test]
+fn nonce_overflow_from_parallel_commit_falls_back_and_continues_suffix() {
+    let sender = account::mock_eoa_address(0);
+    let mut accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
+    accounts.get_mut(&sender).expect("sender account must exist").info.nonce = u64::MAX;
+    let db = Arc::new(InMemoryDB::new(accounts, Default::default(), Default::default()));
+    let mut txs: Vec<_> = (0..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer).collect();
+    txs[0].nonce = u64::MAX;
+
+    let state = ParallelState::new(db, true, false);
+    let scheduler = Scheduler::new(
+        CfgEnv::new_with_spec(SpecId::SHANGHAI),
+        BlockEnv::default(),
+        Arc::new(txs),
+        state,
+        false,
+        None,
+    );
+    scheduler.parallel_execute(Some(23)).expect("nonce overflow must be skipped");
+    let (outcomes, _) = scheduler.take_result_and_state();
+
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert_eq!(
+        outcomes[0],
+        TxExecutionOutcome::Skipped(InvalidTransaction::NonceOverflowInTransaction)
+    );
+    assert!(matches!(outcomes[1], TxExecutionOutcome::Executed(_)));
 }
 
 #[test]
@@ -167,7 +234,10 @@ fn insufficient_funds_falls_back_and_continues_suffix() {
 
     let outcomes = execute_outcomes(txs);
     assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
-    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::InsufficientFunds));
+    assert!(matches!(
+        outcomes[1],
+        TxExecutionOutcome::Skipped(InvalidTransaction::LackOfFundForMaxFee { .. })
+    ));
     assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
 }
 

--- a/tests/native_transfers.rs
+++ b/tests/native_transfers.rs
@@ -1,13 +1,175 @@
 #![allow(missing_docs)]
 
-use grevm::test_utils::{
-    TRANSFER_GAS_LIMIT,
-    common::{account, execute, storage::InMemoryDB},
+use grevm::{
+    ParallelState, Scheduler, SkipReason, TxExecutionOutcome,
+    test_utils::{
+        TRANSFER_GAS_LIMIT,
+        common::{account, execute, storage::InMemoryDB},
+    },
 };
-use revm_context::TxEnv;
-use revm_primitives::{HashMap, TxKind, U256};
+use revm_context::{
+    BlockEnv, CfgEnv, TxEnv,
+    result::{EVMError, InvalidTransaction},
+};
+use revm_primitives::{HashMap, TxKind, U256, hardfork::SpecId};
+use revm_state::Bytecode;
+use std::sync::Arc;
 
 const GIGA_GAS: u64 = 1_000_000_000;
+const MIN_PARALLEL_BLOCK_SIZE: usize = 64;
+
+fn execute_outcomes(txs: Vec<TxEnv>) -> Vec<TxExecutionOutcome> {
+    let accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
+    let db = InMemoryDB::new(accounts, Default::default(), Default::default());
+    execute_outcomes_with_db(db, txs)
+}
+
+fn execute_outcomes_with_db(db: InMemoryDB, txs: Vec<TxEnv>) -> Vec<TxExecutionOutcome> {
+    execute::compare_evm_execute_skipping_invalid_with_spec(db, txs, false, SpecId::SHANGHAI)
+}
+
+fn independent_transfer(index: usize) -> TxEnv {
+    let sender = account::mock_eoa_address(index);
+    TxEnv {
+        caller: sender,
+        kind: TxKind::Call(sender),
+        value: U256::from(1),
+        gas_limit: TRANSFER_GAS_LIMIT,
+        gas_price: 1,
+        nonce: 1,
+        ..TxEnv::default()
+    }
+}
+
+#[test]
+fn nonce_error_falls_back_and_skips_without_incrementing_nonce() {
+    let sender = account::mock_eoa_address(0);
+    let mut txs = vec![
+        independent_transfer(0),
+        TxEnv {
+            caller: sender,
+            kind: TxKind::Call(sender),
+            value: U256::from(1),
+            gas_limit: TRANSFER_GAS_LIMIT,
+            gas_price: 1,
+            nonce: 1,
+            ..TxEnv::default()
+        },
+        TxEnv {
+            caller: sender,
+            kind: TxKind::Call(sender),
+            value: U256::from(1),
+            gas_limit: TRANSFER_GAS_LIMIT,
+            gas_price: 1,
+            nonce: 2,
+            ..TxEnv::default()
+        },
+    ];
+    txs.extend((3..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer));
+
+    let outcomes = execute_outcomes(txs);
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert!(matches!(outcomes[0], TxExecutionOutcome::Executed(_)));
+    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
+}
+
+#[test]
+fn consecutive_nonce_errors_are_revalidated_and_suffix_executes() {
+    let sender = account::mock_eoa_address(0);
+    let sender_tx = |nonce| TxEnv {
+        caller: sender,
+        kind: TxKind::Call(sender),
+        value: U256::from(1),
+        gas_limit: TRANSFER_GAS_LIMIT,
+        gas_price: 1,
+        nonce,
+        ..TxEnv::default()
+    };
+    let mut txs = vec![sender_tx(3), sender_tx(0), sender_tx(1)];
+    txs.extend((3..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer));
+
+    let outcomes = execute_outcomes(txs);
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert_eq!(outcomes[0], TxExecutionOutcome::Skipped(SkipReason::NonceTooHigh));
+    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::NonceTooLow));
+    assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
+}
+
+#[test]
+fn sender_with_code_is_skipped_and_suffix_executes() {
+    let sender = account::mock_eoa_address(0);
+    let mut accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
+    let code = Bytecode::new_raw(vec![0x00].into());
+    let code_hash = code.hash_slow();
+    let sender_account = accounts.get_mut(&sender).expect("sender account must exist");
+    sender_account.info.code_hash = code_hash;
+    sender_account.info.code = Some(code.clone());
+    let mut bytecodes = HashMap::default();
+    bytecodes.insert(code_hash, code);
+    let db = InMemoryDB::new(accounts, bytecodes, Default::default());
+
+    let mut txs = vec![independent_transfer(0), independent_transfer(1)];
+    txs.extend((2..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer));
+
+    let outcomes = execute_outcomes_with_db(db, txs);
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert_eq!(outcomes[0], TxExecutionOutcome::Skipped(SkipReason::SenderNotEoa));
+    assert!(matches!(outcomes[1], TxExecutionOutcome::Executed(_)));
+}
+
+#[test]
+fn nonrecoverable_invalid_transaction_remains_fatal() {
+    let accounts = account::mock_block_accounts(MIN_PARALLEL_BLOCK_SIZE + 1);
+    let db = Arc::new(InMemoryDB::new(accounts, Default::default(), Default::default()));
+    let mut invalid = independent_transfer(0);
+    invalid.gas_limit = 1;
+    let mut txs = vec![invalid];
+    txs.extend((1..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer));
+
+    let state = ParallelState::new(db, true, false);
+    let scheduler = Scheduler::new(
+        CfgEnv::new_with_spec(SpecId::SHANGHAI),
+        BlockEnv::default(),
+        Arc::new(txs),
+        state,
+        false,
+        None,
+    );
+    let error = scheduler
+        .parallel_execute(Some(23))
+        .expect_err("nonrecoverable invalid transaction must abort the block");
+
+    assert_eq!(error.txid, 0);
+    assert!(matches!(
+        error.error,
+        EVMError::Transaction(InvalidTransaction::CallGasCostMoreThanGasLimit { .. })
+    ));
+}
+
+#[test]
+fn insufficient_funds_falls_back_and_continues_suffix() {
+    let sender = account::mock_eoa_address(1);
+    let mut txs = vec![
+        independent_transfer(0),
+        TxEnv {
+            caller: sender,
+            kind: TxKind::Call(sender),
+            value: U256::from(1_000_000_000_000_000_000u128),
+            gas_limit: TRANSFER_GAS_LIMIT,
+            gas_price: 1,
+            nonce: 1,
+            ..TxEnv::default()
+        },
+        independent_transfer(2),
+    ];
+    txs.extend((3..MIN_PARALLEL_BLOCK_SIZE).map(independent_transfer));
+
+    let outcomes = execute_outcomes(txs);
+    assert_eq!(outcomes.len(), MIN_PARALLEL_BLOCK_SIZE);
+    assert_eq!(outcomes[1], TxExecutionOutcome::Skipped(SkipReason::InsufficientFunds));
+    assert!(matches!(outcomes[2], TxExecutionOutcome::Executed(_)));
+}
 
 #[test]
 fn native_gigagas() {


### PR DESCRIPTION
## Summary

- Represent transaction results as either executed or skipped with a stable skip reason.
- Fall back to sequential execution when parallel execution encounters a recoverable invalid transaction.
- Skip nonce and insufficient-balance errors without applying state changes, then continue executing the remaining transactions.
- Keep database, commit, and unknown EVM errors fatal.
- Add sequential-reference, native-transfer, and EIP-7702 coverage for skipped transactions and fallback behavior.

## Validation

- Compared fallback results and final state against a fully sequential executor that skips invalid transactions.
- Replayed Ethereum mainnet and hardfork-coverage fixtures through parallel and sequential execution.