### PR TITLE
feat(evm): Disable create and reserve balance in delegate context

### DIFF
--- a/.github/workflows/grevm-test.yml
+++ b/.github/workflows/grevm-test.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           toolchain: stable
           override: true
+          components: clippy
+
+      # Compile every feature and target, and reject both rustc and Clippy warnings.
+      - name: Run Clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
 
       # GREVM_MIN_PARALLEL_TXS=0 forces the parallel path for the (often small) replayed mainnet
       # blocks so the parallel-vs-sequential comparison is actually exercised.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ autobins = false
 
 [dependencies]
 # Upstream revm v29.0.1 (no fork). The miner reward is skipped during parallel execution via a
-# custom `Handler` (see `scheduler::NoRewardHandler`) and self-computed at commit time, so the
+# `GrevmHandler` in deferred-beneficiary mode and self-computed at commit time, so the
 # previous `Galxe/revm` fork (which only added a `lazy_reward` cfg flag + `ResultAndState` field)
 # is no longer needed.
 revm = { version = "29.0.1", default-features = false }

--- a/benches/continuous.rs
+++ b/benches/continuous.rs
@@ -67,7 +67,7 @@ fn bench_continuous(c: &mut Criterion) {
         group.bench_function("Origin Sequential", |b| {
             b.iter(|| {
                 let _ =
-                    execute::execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &*txs)
+                    execute::execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &txs)
                         .unwrap();
             })
         });

--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -24,15 +24,14 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
     let mut cfg = CfgEnv::new_with_spec(SpecId::SHANGHAI);
     cfg.disable_nonce_check = true;
-    let mut env = BlockEnv::default();
-    env.beneficiary = account::MINER_ADDRESS;
+    let env = BlockEnv { beneficiary: account::MINER_ADDRESS, ..Default::default() };
     let db = Arc::new(db);
     let txs = Arc::new(txs);
 
     let mut group = c.benchmark_group(format!("{}({} txs)", name, txs.len()));
     let mut iter_loop = 0;
     let report_metrics = rand::rng().random_range(0..10);
-    let with_hints = std::env::var("WITH_HINTS").map_or(false, |s| s.parse().unwrap());
+    let with_hints = std::env::var("WITH_HINTS").is_ok_and(|s| s.parse().unwrap());
     group.bench_function("Grevm Parallel", |b| {
         b.iter(|| {
             let recorder = DebuggingRecorder::new();
@@ -66,7 +65,7 @@ fn bench(c: &mut Criterion, name: &str, db: InMemoryDB, txs: Vec<TxEnv>) {
 
     group.bench_function("Origin Sequential", |b| {
         b.iter(|| {
-            let _ = execute::execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &*txs)
+            let _ = execute::execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &txs)
                 .unwrap();
         })
     });
@@ -313,8 +312,8 @@ fn bench_half_chained_erc20(c: &mut Criterion, db_latency_us: u64) {
     let sca = sca[0];
     let eoa_len = eoa.len();
     for i in 0..eoa_len {
-        let addr = eoa[i].clone();
-        let recipient = if i > eoa_len / 2 { eoa[i].clone() } else { eoa[i + 1].clone() };
+        let addr = eoa[i];
+        let recipient = if i > eoa_len / 2 { eoa[i] } else { eoa[i + 1] };
         let tx = TxEnv {
             caller: addr,
             kind: TxKind::Call(sca),
@@ -340,8 +339,8 @@ fn bench_worst_erc20(c: &mut Criterion, db_latency_us: u64) {
     let mut txs = Vec::with_capacity(block_size);
     let sca = sca[0];
     for i in 0..eoa.len() {
-        let addr = eoa[i].clone();
-        let recipient = if i == eoa.len() - 1 { eoa[i].clone() } else { eoa[i + 1].clone() };
+        let addr = eoa[i];
+        let recipient = if i == eoa.len() - 1 { eoa[i] } else { eoa[i + 1] };
         let tx = TxEnv {
             caller: addr,
             kind: TxKind::Call(sca),
@@ -444,7 +443,7 @@ fn bench_worst_uniswap(c: &mut Criterion, db_latency_us: u64, num_eoa: usize, ho
         state.extend(uniswap_contract_accounts);
         bytecodes.extend(uniswap_bytecodes);
         for _ in 0..(block_size / NUM_UNISWAP_CLUSTER) {
-            let data_bytes = if rand::random::<u64>() % 2 == 0 {
+            let data_bytes = if rand::random::<u64>().is_multiple_of(2) {
                 SingleSwap::sell_token0(U256::from(2000))
             } else {
                 SingleSwap::sell_token1(U256::from(2000))
@@ -488,7 +487,7 @@ fn bench_half_chained_uniswap(
         state.extend(uniswap_contract_accounts);
         bytecodes.extend(uniswap_bytecodes);
         for _ in 0..(num_uniswap / NUM_UNISWAP_CLUSTER) {
-            let data_bytes = if rand::random::<u64>() % 2 == 0 {
+            let data_bytes = if rand::random::<u64>().is_multiple_of(2) {
                 SingleSwap::sell_token0(U256::from(2000))
             } else {
                 SingleSwap::sell_token1(U256::from(2000))
@@ -562,7 +561,7 @@ fn bench_hybrid(c: &mut Criterion, db_latency_us: u64, num_eoa: usize, hot_ratio
             txs.push(tx);
         }
     }
-    state.extend(erc20_contract_accounts.into_iter());
+    state.extend(erc20_contract_accounts);
 
     let mut bytecodes = erc20_bytecodes;
     const NUM_UNISWAP_CLUSTER: usize = 2;
@@ -572,7 +571,7 @@ fn bench_hybrid(c: &mut Criterion, db_latency_us: u64, num_eoa: usize, hot_ratio
         state.extend(uniswap_contract_accounts);
         bytecodes.extend(uniswap_bytecodes);
         for _ in 0..(num_uniswap / NUM_UNISWAP_CLUSTER) {
-            let data_bytes = if rand::random::<u64>() % 2 == 0 {
+            let data_bytes = if rand::random::<u64>().is_multiple_of(2) {
                 SingleSwap::sell_token0(U256::from(2000))
             } else {
                 SingleSwap::sell_token1(U256::from(2000))

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,10 +29,18 @@ This builds and runs:
 | `tests/native_transfers.rs` | raw value-transfer workloads (independent / chained / hybrid) |
 | `tests/uniswap.rs` | Uniswap swap workloads |
 | `tests/eip-7702.rs` | synthetic EIP-7702 scenarios: delegate / re-delegate / reset / multi-authority; storage preservation when an already-delegated EOA with storage is re-delegated (the block-22546209 bug); and interaction with `CREATE`/`CREATE2` and `SELFDESTRUCT` |
+| `tests/delegated_safety.rs` | opt-in delegated CREATE/CREATE2 and reserve-balance policy matrix; ordinary CREATE/CREATE2 compatibility, ample/exact/insufficient reserve boundaries, first-debit balance protection, authorization-refund preservation, rollback, SELFDESTRUCT, and a coordinated stale speculative read that must be invalidated and re-executed before matching sequential execution |
 | `tests/mainnet.rs` | replays real mainnet blocks from fixtures (skips if none present) |
 
-Every integration test compares **Grevm parallel execution against a sequential revm reference**
-and asserts both the per-transaction results and the final bundle state match.
+Compatibility integration tests compare **Grevm parallel execution against a sequential revm
+reference** and assert both per-transaction results and final bundle state. The grevm-specific
+delegated-safety tests use explicit expected outcomes; their combined policy matrix also compares
+parallel execution against Grevm's forced-sequential path.
+
+The shared revm-compatibility helpers explicitly use `DelegatedSafetyConfig::disabled()`: mainnet
+replay and upstream EIP-7702 regression tests therefore remain pure grevm-vs-revm equivalence
+checks even if the policy defaults change. Policy-enabled behavior is tested separately in
+`tests/delegated_safety.rs`.
 
 > Plain `cargo test` (without `--features test-utils`) only builds the library; the integration
 > tests and benches require the feature.
@@ -50,6 +58,11 @@ and asserts both the per-transaction results and the final bundle state match.
 Benchmark-only tuning (read by `benches/gigagas.rs`): `NUM_EOA` (default `100000`), `HOT_RATIO`
 (`0.0`), `DB_LATENCY_US` (`0`), `WITH_HINTS` (`false`), `DEPENDENCY_RATIO` (`0.1`),
 `DEPENDENCY_DISTANCE` (`8`), `FILTER` (substring filter for which sub-benchmarks to run).
+
+These execution knobs are represented by `GrevmConfig` together with
+`DelegatedSafetyConfig`. `Scheduler::new(...)` calls `GrevmConfig::from_env()` for compatibility;
+production integrations can use `Scheduler::new_with_config(...)` and `Scheduler::execute()` to
+avoid process-global environment reads and make the block execution policy explicit.
 
 ## Replaying real mainnet blocks
 
@@ -79,6 +92,10 @@ This writes `test_data/mainnet_blocks/<block>/{block,txs,pre_state}.json`.
 ```bash
 # Replay every single-block fixture under test_data/mainnet_blocks/
 GREVM_MIN_PARALLEL_TXS=0 cargo test --features test-utils --test mainnet replay_mainnet_blocks
+
+# Replay every hardfork-boundary fixture under test_data/spec_coverage/
+GREVM_MIN_PARALLEL_TXS=0 GREVM_MAINNET_BLOCKS=test_data/spec_coverage \
+  cargo test --features test-utils --test mainnet replay_mainnet_blocks
 
 # Replay just one block
 GREVM_MIN_PARALLEL_TXS=0 GREVM_MAINNET_BLOCK=25323281 \
@@ -204,6 +221,7 @@ gracefully.
 ```
 test_data/
 ├── mainnet_blocks/<block>/{block,txs,pre_state}.json        # single real blocks (fetch_block)
+├── spec_coverage/<block>/{block,txs,pre_state}.json         # hardfork-boundary regression set
 └── con_eth_blocks/<start>_<end>/{block,txs,pre_state}.json   # merged big blocks (fetch_continuous)
 ```
 

--- a/src/async_commit.rs
+++ b/src/async_commit.rs
@@ -164,7 +164,7 @@ where
             }
         }
         // Self-compute the miner reward: upstream revm credits the coinbase inside execution, which
-        // grevm suppresses with a custom `Handler` (see `scheduler::NoRewardHandler`) and applies
+        // grevm suppresses with `GrevmHandler` in deferred-beneficiary mode and applies
         // here instead. This reproduces what the dropped `Galxe/revm` fork returned via
         // `ResultAndState.lazy_reward`.
         let reward = self.compute_reward(tx_env, &result);

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,0 +1,103 @@
+use crate::{ParallelState, utils::fork_join_util};
+use parking_lot::Mutex;
+use revm::DatabaseRef;
+use revm_database::{BundleState, TransitionState, states::bundle_state::BundleRetention};
+use revm_primitives::Address;
+use std::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+/// A vector supporting concurrent writes to caller-guaranteed disjoint indices.
+struct DisjointVec<T>(UnsafeCell<Vec<T>>);
+
+// SAFETY: all use sites partition indices through `fork_join_util`.
+unsafe impl<T: Send> Sync for DisjointVec<T> {}
+
+impl<T> DisjointVec<T> {
+    fn new(values: Vec<T>) -> Self {
+        Self(UnsafeCell::new(values))
+    }
+
+    /// SAFETY: no other thread may access `index` concurrently.
+    unsafe fn set(&self, index: usize, value: T) {
+        unsafe { (&mut (*self.0.get()))[index] = value };
+    }
+
+    fn into_inner(self) -> Vec<T> {
+        self.0.into_inner()
+    }
+}
+
+/// Parallel transition application for an initially empty bundle.
+pub trait ParallelBundleState {
+    /// Apply transitions and create reverts in parallel.
+    fn parallel_apply_transitions_and_create_reverts(
+        &mut self,
+        transitions: TransitionState,
+        retention: BundleRetention,
+    );
+}
+
+impl ParallelBundleState for BundleState {
+    fn parallel_apply_transitions_and_create_reverts(
+        &mut self,
+        transitions: TransitionState,
+        retention: BundleRetention,
+    ) {
+        if !self.state.is_empty() {
+            self.apply_transitions_and_create_reverts(transitions, retention);
+            return;
+        }
+
+        let include_reverts = retention.includes_reverts();
+        let revert_capacity = if include_reverts { transitions.transitions.len() } else { 0 };
+        let transitions = transitions.transitions;
+        let addresses: Vec<Address> = transitions.keys().copied().collect();
+        let reverts = DisjointVec::new(vec![None; revert_capacity]);
+        let bundle = DisjointVec::new(vec![None; transitions.len()]);
+        let state_size = AtomicUsize::new(0);
+        let reverts_size = AtomicUsize::new(0);
+        let contracts = Mutex::new(revm_primitives::HashMap::default());
+
+        fork_join_util(transitions.len(), None, |start, end, _| {
+            for (position, address) in addresses.iter().enumerate().take(end).skip(start) {
+                let transition = transitions.get(address).cloned().expect("address comes from map");
+                if let Some((hash, bytecode)) = transition.has_new_contract() {
+                    contracts.lock().insert(hash, bytecode.clone());
+                }
+                let present = transition.present_bundle_account();
+                if let Some(revert) = transition.create_revert() {
+                    state_size.fetch_add(present.size_hint(), Ordering::Relaxed);
+                    unsafe { bundle.set(position, Some((*address, present))) };
+                    if include_reverts {
+                        reverts_size.fetch_add(revert.size_hint(), Ordering::Relaxed);
+                        unsafe { reverts.set(position, Some((*address, revert))) };
+                    }
+                }
+            }
+        });
+
+        self.state_size = state_size.load(Ordering::Acquire);
+        self.reverts_size = reverts_size.load(Ordering::Acquire);
+        self.state.reserve(transitions.len());
+        self.state.extend(bundle.into_inner().into_iter().flatten());
+        self.reverts.push(reverts.into_inner().into_iter().flatten().collect());
+        self.contracts = contracts.into_inner();
+    }
+}
+
+/// Parallel bundle extraction from `ParallelState`.
+pub trait ParallelTakeBundle {
+    /// Take the accumulated bundle using parallel transition application.
+    fn parallel_take_bundle(&mut self, retention: BundleRetention) -> BundleState;
+}
+
+impl<DB: DatabaseRef> ParallelTakeBundle for ParallelState<DB> {
+    fn parallel_take_bundle(&mut self, retention: BundleRetention) -> BundleState {
+        if let Some(transitions) = self.transition_state.as_mut().map(TransitionState::take) {
+            self.bundle_state.parallel_apply_transitions_and_create_reverts(transitions, retention);
+        }
+        self.take_bundle()
+    }
+}

--- a/src/cache_db.rs
+++ b/src/cache_db.rs
@@ -1,142 +1,11 @@
 use crate::{
-    AccountBasic, LocationAndType, MemoryEntry, MemoryValue, ParallelState, ReadVersion, TxId,
-    TxVersion, fork_join_util, scheduler::MVMemory,
+    AccountBasic, LocationAndType, MVMemory, MemoryEntry, MemoryValue, ReadVersion, TxId, TxVersion,
 };
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
-use parking_lot::Mutex;
 use revm::{Database, DatabaseRef};
-use revm_database::{BundleState, TransitionState, states::bundle_state::BundleRetention};
 use revm_primitives::{Address, B256, U256, hardfork::SpecId};
 use revm_state::{AccountInfo, Bytecode, EvmState};
-use std::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicUsize, Ordering},
-};
-
-/// A wrapper around `Vec<T>` that allows disjoint parallel writes to different indices.
-///
-/// SAFETY: Callers must ensure that concurrent accesses target non-overlapping index ranges.
-/// This is guaranteed by `fork_join_util` which partitions indices into disjoint ranges.
-struct DisjointVec<T>(UnsafeCell<Vec<T>>);
-
-// SAFETY: DisjointVec is only used within fork_join_util where each thread writes to
-// a disjoint range of indices, so no data race can occur.
-unsafe impl<T: Send> Sync for DisjointVec<T> {}
-
-impl<T> DisjointVec<T> {
-    fn new(vec: Vec<T>) -> Self {
-        Self(UnsafeCell::new(vec))
-    }
-
-    /// SAFETY: Caller must ensure no other thread accesses the same index concurrently.
-    unsafe fn set(&self, index: usize, value: T) {
-        unsafe { (&mut (*self.0.get()))[index] = value };
-    }
-
-    fn into_inner(self) -> Vec<T> {
-        self.0.into_inner()
-    }
-}
-
-/// A trait that provides functionality for applying state transitions in parallel
-/// and creating reverts for a `BundleState`.
-///
-/// This trait is designed to optimize the process of applying transitions and
-/// generating reverts by leveraging parallelism, especially when dealing with
-/// large sets of transitions.
-pub trait ParallelBundleState {
-    /// apply transitions to create reverts for BundleState in parallel
-    fn parallel_apply_transitions_and_create_reverts(
-        &mut self,
-        transitions: TransitionState,
-        retention: BundleRetention,
-    );
-}
-
-impl ParallelBundleState for BundleState {
-    fn parallel_apply_transitions_and_create_reverts(
-        &mut self,
-        transitions: TransitionState,
-        retention: BundleRetention,
-    ) {
-        if !self.state.is_empty() {
-            self.apply_transitions_and_create_reverts(transitions, retention);
-            return;
-        }
-
-        let include_reverts = retention.includes_reverts();
-        // pessimistically pre-allocate assuming _all_ accounts changed.
-        let reverts_capacity = if include_reverts { transitions.transitions.len() } else { 0 };
-        let transitions = transitions.transitions;
-        let addresses: Vec<Address> = transitions.keys().cloned().collect();
-        let reverts = DisjointVec::new(vec![None; reverts_capacity]);
-        let bundle_state = DisjointVec::new(vec![None; transitions.len()]);
-        let state_size = AtomicUsize::new(0);
-        let reverts_size = AtomicUsize::new(0);
-        let contracts = Mutex::new(revm_primitives::HashMap::default());
-
-        fork_join_util(transitions.len(), None, |start_pos, end_pos, _| {
-            for pos in start_pos..end_pos {
-                let address = addresses[pos];
-                let transition = transitions.get(&address).cloned().unwrap();
-                // add new contract if it was created/changed.
-                if let Some((hash, new_bytecode)) = transition.has_new_contract() {
-                    contracts.lock().insert(hash, new_bytecode.clone());
-                }
-                let present_bundle = transition.present_bundle_account();
-                let revert = transition.create_revert();
-                if let Some(revert) = revert {
-                    state_size.fetch_add(present_bundle.size_hint(), Ordering::Relaxed);
-                    unsafe { bundle_state.set(pos, Some((address, present_bundle))) };
-                    if include_reverts {
-                        reverts_size.fetch_add(revert.size_hint(), Ordering::Relaxed);
-                        unsafe { reverts.set(pos, Some((address, revert))) };
-                    }
-                }
-            }
-        });
-        self.state_size = state_size.load(Ordering::Acquire);
-        self.reverts_size = reverts_size.load(Ordering::Acquire);
-
-        // much faster than bundle_state.into_iter().filter_map(|r| r).collect()
-        self.state.reserve(transitions.len());
-        for bundle in bundle_state.into_inner() {
-            if let Some((address, state)) = bundle {
-                self.state.insert(address, state);
-            }
-        }
-        let mut final_reverts = Vec::with_capacity(reverts_capacity);
-        for revert in reverts.into_inner() {
-            if let Some(r) = revert {
-                final_reverts.push(r);
-            }
-        }
-        self.reverts.push(final_reverts);
-        self.contracts = contracts.into_inner();
-    }
-}
-
-/// Provides functionality for extracting a `BundleState` from a `ParallelState`
-/// while applying state transitions in parallel.
-///
-/// This trait is designed to optimize the process of taking a `BundleState` by leveraging
-/// parallelism to apply transitions and generate reverts efficiently. It ensures that the
-/// resulting `BundleState` reflects the latest state changes based on the provided retention
-/// policy.
-pub trait ParallelTakeBundle {
-    /// take bundle in parallel
-    fn parallel_take_bundle(&mut self, retention: BundleRetention) -> BundleState;
-}
-
-impl<DB: DatabaseRef> ParallelTakeBundle for ParallelState<DB> {
-    fn parallel_take_bundle(&mut self, retention: BundleRetention) -> BundleState {
-        if let Some(transition_state) = self.transition_state.as_mut().map(TransitionState::take) {
-            self.bundle_state
-                .parallel_apply_transitions_and_create_reverts(transition_state, retention);
-        }
-        self.take_bundle()
-    }
-}
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Debug)]
 pub(crate) struct CacheDB<'a, DB>
@@ -268,14 +137,14 @@ where
                 let code_changed = has_code &&
                     account.info.code.is_some() &&
                     read_account
-                        .map_or(true, |basic| basic.code_hash != Some(account.info.code_hash));
+                        .is_none_or(|basic| basic.code_hash != Some(account.info.code_hash));
                 if code_changed {
                     // Record whether this code write *created* the account (`CREATE`/`CREATE2`),
                     // which clears its storage, versus merely re-pointing it (an EIP-7702
                     // (re)delegation), which preserves the account's pre-existing storage. Later
                     // txs use this to decide whether an unwritten slot reads as zero or from the
                     // base database (see `storage_cleared_in_block`).
-                    let location = LocationAndType::Code(address.clone());
+                    let location = LocationAndType::Code(*address);
                     write_set.insert(location.clone());
                     self.mv_memory.entry(location).or_default().insert(
                         self.current_tx.txid,
@@ -296,7 +165,7 @@ where
                         basic.nonce != account.info.nonce || basic.balance != account.info.balance
                     })
                 {
-                    let location = LocationAndType::Basic(address.clone());
+                    let location = LocationAndType::Basic(*address);
                     write_set.insert(location.clone());
                     self.mv_memory.entry(location).or_default().insert(
                         self.current_tx.txid,
@@ -335,22 +204,16 @@ where
         let mut read_version = ReadVersion::Storage;
         let location = LocationAndType::Code(address);
         // 1. read from multi-version memory
-        if let Some(written_transactions) = self.mv_memory.get(&location) {
-            if let Some((&txid, entry)) =
-                written_transactions.range(..self.current_tx.txid).next_back()
-            {
-                match &entry.data {
-                    MemoryValue::Code(code, _) => {
-                        result = Some(code.clone());
-                        if entry.estimate {
-                            self.estimate_txs.insert(txid);
-                        }
-                        read_version =
-                            ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
-                    }
-                    _ => {}
-                }
+        if let Some(written_transactions) = self.mv_memory.get(&location) &&
+            let Some((&txid, entry)) =
+                written_transactions.range(..self.current_tx.txid).next_back() &&
+            let MemoryValue::Code(code, _) = &entry.data
+        {
+            result = Some(code.clone());
+            if entry.estimate {
+                self.estimate_txs.insert(txid);
             }
+            read_version = ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
         }
         // 2. read from database
         if result.is_none() {
@@ -391,42 +254,41 @@ where
         } else {
             let mut read_version = ReadVersion::Storage;
             let mut read_account = AccountBasic { balance: U256::ZERO, nonce: 0, code_hash: None };
-            let location = LocationAndType::Basic(address.clone());
+            let location = LocationAndType::Basic(address);
             // 1. read from multi-version memory
             let mut clear_destructed_entry = false;
-            if let Some(written_transactions) = self.mv_memory.get(&location) {
-                if let Some((&txid, entry)) =
+            if let Some(written_transactions) = self.mv_memory.get(&location) &&
+                let Some((&txid, entry)) =
                     written_transactions.range(..self.current_tx.txid).next_back()
-                {
-                    match &entry.data {
-                        MemoryValue::Basic(info) => {
-                            result = Some(info.clone());
-                            read_account = AccountBasic {
-                                balance: info.balance,
-                                nonce: info.nonce,
-                                code_hash: if info.is_empty_code_hash() {
-                                    None
-                                } else {
-                                    Some(info.code_hash)
-                                },
-                            };
-                            if entry.estimate {
-                                self.estimate_txs.insert(txid);
-                            }
-                            read_version =
-                                ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
-                        }
-                        MemoryValue::SelfDestructed => {
-                            if self.commit_idx.load(Ordering::Acquire) == self.current_tx.txid {
-                                // make sure read after the latest self-destructed
-                                clear_destructed_entry = true;
+            {
+                match &entry.data {
+                    MemoryValue::Basic(info) => {
+                        result = Some(info.clone());
+                        read_account = AccountBasic {
+                            balance: info.balance,
+                            nonce: info.nonce,
+                            code_hash: if info.is_empty_code_hash() {
+                                None
                             } else {
-                                self.accurate_origin = false;
-                                result = Some(AccountInfo::default());
-                            }
+                                Some(info.code_hash)
+                            },
+                        };
+                        if entry.estimate {
+                            self.estimate_txs.insert(txid);
                         }
-                        _ => {}
+                        read_version =
+                            ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
                     }
+                    MemoryValue::SelfDestructed => {
+                        if self.commit_idx.load(Ordering::Acquire) == self.current_tx.txid {
+                            // make sure read after the latest self-destructed
+                            clear_destructed_entry = true;
+                        } else {
+                            self.accurate_origin = false;
+                            result = Some(AccountInfo::default());
+                        }
+                    }
+                    _ => {}
                 }
             }
             if clear_destructed_entry {
@@ -454,10 +316,11 @@ where
             self.read_set.insert(location, read_version);
         }
 
-        if let Some(info) = &mut result {
-            if !info.is_empty_code_hash() && info.code.is_none() {
-                info.code = Some(self.code_by_address(address.clone(), info.code_hash)?);
-            }
+        if let Some(info) = &mut result &&
+            !info.is_empty_code_hash() &&
+            info.code.is_none()
+        {
+            info.code = Some(self.code_by_address(address, info.code_hash)?);
         }
         Ok(result)
     }
@@ -469,20 +332,18 @@ where
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let mut result = None;
         let mut read_version = ReadVersion::Storage;
-        let location = LocationAndType::Storage(address.clone(), index.clone());
+        let location = LocationAndType::Storage(address, index);
         // 1. read from multi-version memory
-        if let Some(written_transactions) = self.mv_memory.get(&location) {
-            if let Some((&txid, entry)) =
-                written_transactions.range(..self.current_tx.txid).next_back()
-            {
-                if let MemoryValue::Storage(slot) = &entry.data {
-                    result = Some(*slot);
-                    if entry.estimate {
-                        self.estimate_txs.insert(txid);
-                    }
-                    read_version = ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
-                }
+        if let Some(written_transactions) = self.mv_memory.get(&location) &&
+            let Some((&txid, entry)) =
+                written_transactions.range(..self.current_tx.txid).next_back() &&
+            let MemoryValue::Storage(slot) = &entry.data
+        {
+            result = Some(*slot);
+            if entry.estimate {
+                self.estimate_txs.insert(txid);
             }
+            read_version = ReadVersion::MvMemory(TxVersion::new(txid, entry.incarnation));
         }
         // 2. read from database
         if result.is_none() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,87 @@
+use crate::DelegatedSafetyConfig;
+
+/// Runtime configuration for one grevm scheduler.
+///
+/// Environment variables are read once when [`Self::from_env`] is called. Callers that need
+/// consensus-stable behavior should construct this value explicitly and pass it to
+/// `Scheduler::new_with_config`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GrevmConfig {
+    /// Number of speculative execution workers.
+    pub concurrency_level: usize,
+    /// Execute the whole block through the sequential path.
+    pub force_sequential: bool,
+    /// Blocks smaller than this threshold use the sequential path.
+    pub min_parallel_txs: usize,
+    /// EIP-7702 delegated-account safety policy.
+    pub delegated_safety: DelegatedSafetyConfig,
+}
+
+impl GrevmConfig {
+    /// Builds the legacy grevm runtime configuration from environment variables.
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            concurrency_level: env_or("GREVM_CONCURRENT_LEVEL", defaults.concurrency_level),
+            force_sequential: env_or("GREVM_FALLBACK_SEQUENTIAL", defaults.force_sequential),
+            min_parallel_txs: env_or("GREVM_MIN_PARALLEL_TXS", defaults.min_parallel_txs),
+            delegated_safety: defaults.delegated_safety,
+        }
+    }
+
+    /// Overrides the delegated-account policy while preserving all execution settings.
+    pub fn with_delegated_safety(mut self, delegated_safety: DelegatedSafetyConfig) -> Self {
+        self.delegated_safety = delegated_safety;
+        self
+    }
+}
+
+impl Default for GrevmConfig {
+    fn default() -> Self {
+        Self {
+            concurrency_level: std::thread::available_parallelism().map_or(8, |value| value.get()),
+            force_sequential: false,
+            min_parallel_txs: 64,
+            delegated_safety: DelegatedSafetyConfig::default(),
+        }
+    }
+}
+
+fn env_or<T>(name: &str, default: T) -> T
+where
+    T: std::str::FromStr,
+{
+    std::env::var(name).ok().and_then(|value| value.parse().ok()).unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_configuration_is_safe_and_bounded() {
+        let config = GrevmConfig::default();
+        assert!(config.concurrency_level > 0);
+        assert_eq!(config.min_parallel_txs, 64);
+        assert!(!config.force_sequential);
+        assert!(!config.delegated_safety.forbid_delegated_create);
+        assert!(!config.delegated_safety.reserve_delegated_balance);
+    }
+
+    #[test]
+    fn delegated_policy_builder_preserves_scheduler_settings() {
+        let config = GrevmConfig {
+            concurrency_level: 3,
+            force_sequential: true,
+            min_parallel_txs: 7,
+            delegated_safety: DelegatedSafetyConfig::default(),
+        }
+        .with_delegated_safety(DelegatedSafetyConfig::enabled());
+
+        assert_eq!(config.concurrency_level, 3);
+        assert!(config.force_sequential);
+        assert_eq!(config.min_parallel_txs, 7);
+        assert!(config.delegated_safety.forbid_delegated_create);
+        assert!(config.delegated_safety.reserve_delegated_balance);
+    }
+}

--- a/src/delegated_safety/handler.rs
+++ b/src/delegated_safety/handler.rs
@@ -1,0 +1,365 @@
+use super::{ReserveJournalExt, ReservePlanner};
+use metrics::counter;
+use revm::{
+    handler::{EvmTr, EvmTrError, FrameResult, FrameTr, Handler, post_execution},
+    interpreter::{
+        CallOutcome, InitialAndFloorGas, InstructionResult, InterpreterResult,
+        interpreter_action::FrameInit,
+    },
+};
+use revm_context::{
+    BlockEnv, ContextTr, JournalTr, Transaction, TxEnv,
+    journaled_state::JournalCheckpoint,
+    result::{ExecutionResult, HaltReason, InvalidTransaction},
+};
+use revm_primitives::Bytes;
+use revm_state::EvmState;
+
+use crate::TxId;
+use core::cell::Cell;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BeneficiaryMode {
+    /// Parallel execution leaves the beneficiary update to the ordered commit path.
+    Deferred,
+    /// Sequential execution applies the beneficiary update before committing the transaction.
+    Immediate,
+}
+
+impl BeneficiaryMode {
+    fn apply<EVM, ERROR>(self, evm: &mut EVM, exec_result: &mut FrameResult) -> Result<(), ERROR>
+    where
+        EVM: EvmTr<Context: ContextTr>,
+        ERROR: EvmTrError<EVM>,
+    {
+        match self {
+            Self::Deferred => Ok(()),
+            Self::Immediate => {
+                post_execution::reward_beneficiary(evm.ctx(), exec_result.gas()).map_err(From::from)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ReserveMode<'a> {
+    /// Preserve revm's default pre-execution lifecycle; do not checkpoint or scan the journal.
+    NoReserve,
+    /// Check delegated debits against the future costs of transactions after `txid`.
+    WithReserve {
+        /// Logical position in the original block, including during sequential suffix fallback.
+        txid: TxId,
+        /// Shared lazy costs for transactions strictly after `txid`.
+        planner: &'a ReservePlanner,
+    },
+}
+
+impl<'a> ReserveMode<'a> {
+    /// Converts the scheduler's optional planner into an explicit transaction execution mode.
+    pub(crate) fn from_planner(txid: TxId, planner: Option<&'a ReservePlanner>) -> Self {
+        match planner {
+            Some(planner) => Self::WithReserve { txid, planner },
+            None => Self::NoReserve,
+        }
+    }
+}
+
+/// Grevm transaction handler with independent reserve and beneficiary policies.
+///
+/// `ReserveMode::NoReserve` dispatches to a handler that overrides only beneficiary handling, so
+/// validation, pre-execution, execution, and post-execution ordering come directly from revm's
+/// default `Handler` implementation. `ReserveMode::WithReserve` dispatches to a handler that also
+/// overrides `pre_execution` to insert the reserve checkpoint.
+///
+/// The handler deliberately relies on revm's native journal entries and checkpoints. Internal
+/// frame reverts have already removed their entries when `has_reserve_violation` runs, so no
+/// second undo stack or balance-mutation wrapper is needed.
+///
+/// When reserve protection is enabled, `pre_execution` creates a checkpoint after revm has
+/// deducted gas, bumped a CALL sender's nonce, and applied EIP-7702 authorizations. Revm's default
+/// lifecycle then executes the transaction. This handler reproduces revm's post-execution
+/// ordering, inserts the reserve check after caller reimbursement, and applies the configured
+/// beneficiary policy:
+///
+/// ```text
+/// validate -> deduct gas / bump CALL nonce -> apply EIP-7702 authorizations
+///                                                        |
+///                                              execution checkpoint
+///                                                        |
+///           execute -> gas/refund rules -> reimburse caller -> scan delegated debits
+///                                                        |
+///                              +-------------------------+-----------------------+
+///                              |                                                 |
+///                         reserve holds                                  reserve violated
+///                              |                                                 |
+///                     commit checkpoint                    revert checkpoint + force REVERT
+///                                                                        |
+///                                                   restore CREATE-tx nonce if needed
+///                                                                        |
+///                                        keep authorization refund, reimburse caller
+///                                                                        |
+///                                                               reward beneficiary
+/// ```
+///
+/// With reserve protection disabled, no checkpoint or journal scan is performed.
+///
+/// Consequently, a reserve violation cannot become a free skipped transaction: execution state
+/// is reverted, while charged gas, the transaction nonce, and authorization effects survive.
+pub(crate) struct GrevmHandler<'a> {
+    /// Selects the default or reserve-aware revm handler implementation.
+    reserve_mode: ReserveMode<'a>,
+    /// Chooses who applies the beneficiary write; it does not change reserve semantics.
+    beneficiary_mode: BeneficiaryMode,
+}
+
+impl<'a> GrevmHandler<'a> {
+    pub(crate) fn new(reserve_mode: ReserveMode<'a>, beneficiary_mode: BeneficiaryMode) -> Self {
+        Self { reserve_mode, beneficiary_mode }
+    }
+
+    pub(crate) fn run<EVM, ERROR, FRAME>(
+        self,
+        evm: &mut EVM,
+    ) -> Result<ExecutionResult<HaltReason>, ERROR>
+    where
+        EVM: EvmTr<
+                Context: ContextTr<
+                    Block = BlockEnv,
+                    Tx = TxEnv,
+                    Journal: JournalTr<State = EvmState> + ReserveJournalExt,
+                >,
+                Frame = FRAME,
+            >,
+        ERROR: EvmTrError<EVM>,
+        FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+    {
+        match self.reserve_mode {
+            ReserveMode::NoReserve => NoReserveHandler::new(self.beneficiary_mode).run(evm),
+            ReserveMode::WithReserve { txid, planner } => {
+                WithReserveHandler::new(txid, planner, self.beneficiary_mode).run(evm)
+            }
+        }
+    }
+}
+
+/// `ReserveMode::NoReserve` implementation. Deliberately does not override `pre_execution`.
+struct NoReserveHandler<EVM, ERROR, FRAME> {
+    beneficiary_mode: BeneficiaryMode,
+    _phantom: core::marker::PhantomData<(EVM, ERROR, FRAME)>,
+}
+
+impl<EVM, ERROR, FRAME> NoReserveHandler<EVM, ERROR, FRAME> {
+    fn new(beneficiary_mode: BeneficiaryMode) -> Self {
+        Self { beneficiary_mode, _phantom: core::marker::PhantomData }
+    }
+}
+
+impl<EVM, ERROR, FRAME> Handler for NoReserveHandler<EVM, ERROR, FRAME>
+where
+    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState>>, Frame = FRAME>,
+    ERROR: EvmTrError<EVM>,
+    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+{
+    type Evm = EVM;
+    type Error = ERROR;
+    type HaltReason = HaltReason;
+
+    fn reward_beneficiary(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut FrameResult,
+    ) -> Result<(), Self::Error> {
+        self.beneficiary_mode.apply(evm, exec_result)
+    }
+}
+
+/// `ReserveMode::WithReserve` implementation. Adds only the two hooks needed by the guard.
+struct WithReserveHandler<'a, EVM, ERROR, FRAME> {
+    /// Logical position in the original block, including during sequential suffix fallback.
+    txid: TxId,
+    /// Shared lazy costs for transactions strictly after `txid`.
+    planner: &'a ReservePlanner,
+    beneficiary_mode: BeneficiaryMode,
+    /// Transaction-execution checkpoint created by `pre_execution` and consumed exactly once by
+    /// `reward_beneficiary`. `Cell` is needed because revm exposes both hooks through `&self`.
+    execution_checkpoint: Cell<Option<JournalCheckpoint>>,
+    _phantom: core::marker::PhantomData<(EVM, ERROR, FRAME)>,
+}
+
+impl<'a, EVM, ERROR, FRAME> WithReserveHandler<'a, EVM, ERROR, FRAME> {
+    fn new(txid: TxId, planner: &'a ReservePlanner, beneficiary_mode: BeneficiaryMode) -> Self {
+        Self {
+            txid,
+            planner,
+            beneficiary_mode,
+            execution_checkpoint: Cell::new(None),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<EVM, ERROR, FRAME> Handler for WithReserveHandler<'_, EVM, ERROR, FRAME>
+where
+    EVM: EvmTr<
+            Context: ContextTr<
+                Block = BlockEnv,
+                Tx = TxEnv,
+                Journal: JournalTr<State = EvmState> + ReserveJournalExt,
+            >,
+            Frame = FRAME,
+        >,
+    ERROR: EvmTrError<EVM>,
+    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+{
+    type Evm = EVM;
+    type Error = ERROR;
+    type HaltReason = HaltReason;
+
+    fn pre_execution(&self, evm: &mut Self::Evm) -> Result<u64, Self::Error> {
+        // This is revm's default `pre_execution` sequence. The trait has no hook after
+        // authorization processing, so these three calls are repeated here solely to place the
+        // reserve checkpoint at the transaction/execution boundary.
+        self.validate_against_state_and_deduct_caller(evm)?;
+        self.load_accounts(evm)?;
+        let eip7702_refund = self.apply_eip7702_auth_list(evm)?;
+
+        debug_assert!(self.execution_checkpoint.get().is_none());
+        self.execution_checkpoint.set(Some(evm.ctx().journal_mut().checkpoint()));
+
+        Ok(eip7702_refund)
+    }
+
+    fn post_execution(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut FrameResult,
+        init_and_floor_gas: InitialAndFloorGas,
+        eip7702_gas_refund: i64,
+    ) -> Result<(), Self::Error> {
+        // Preserve the gas state before revm merges execution refunds with the authorization
+        // refund. A reserve violation rolls back execution, so only the independently earned
+        // EIP-7702 authorization refund may be reapplied to this snapshot.
+        let execution_gas = *exec_result.gas();
+
+        self.refund(evm, exec_result, eip7702_gas_refund);
+        self.eip7623_check_gas_floor(evm, exec_result, init_and_floor_gas);
+        self.reimburse_caller(evm, exec_result)?;
+        self.enforce_reserve(
+            evm,
+            exec_result,
+            execution_gas,
+            init_and_floor_gas,
+            eip7702_gas_refund,
+        )?;
+        self.beneficiary_mode.apply(evm, exec_result)
+    }
+}
+
+impl<EVM, ERROR, FRAME> WithReserveHandler<'_, EVM, ERROR, FRAME>
+where
+    EVM: EvmTr<
+            Context: ContextTr<
+                Block = BlockEnv,
+                Tx = TxEnv,
+                Journal: JournalTr<State = EvmState> + ReserveJournalExt,
+            >,
+            Frame = FRAME,
+        >,
+    ERROR: EvmTrError<EVM>,
+    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+{
+    fn enforce_reserve(
+        &self,
+        evm: &mut EVM,
+        exec_result: &mut FrameResult,
+        execution_gas: revm::interpreter::Gas,
+        init_and_floor_gas: InitialAndFloorGas,
+        eip7702_gas_refund: i64,
+    ) -> Result<(), ERROR> {
+        let execution_checkpoint = self
+            .execution_checkpoint
+            .take()
+            .expect("reserve checkpoint must be created before beneficiary processing");
+
+        // Revm invokes this hook after refund calculation, gas-floor enforcement, and caller
+        // reimbursement. The inspected balance is therefore the real post-transaction balance.
+        if self.has_reserve_violation(evm, execution_checkpoint)? {
+            // CALL transactions bumped their sender nonce before the checkpoint. A top-level
+            // CREATE transaction bumps it while constructing the first frame, so that one nonce
+            // must be restored explicitly after reverting the execution checkpoint.
+            let recreate_sender_nonce = evm.ctx_ref().tx().kind().is_create();
+            evm.ctx().journal_mut().checkpoint_revert(execution_checkpoint);
+            *exec_result = reserve_violation_result(execution_gas);
+            if recreate_sender_nonce {
+                reapply_create_sender_nonce::<EVM, ERROR>(evm)?;
+            }
+
+            // Execution-state refunds disappeared with the reverted checkpoint. Reapply only the
+            // authorization refund, then recompute both the normal refund cap and EIP-7623 floor
+            // from the pre-refund execution gas. The first reimbursement was also reverted, so
+            // apply it again using this synthetic top-level REVERT result.
+            self.refund(evm, exec_result, eip7702_gas_refund);
+            self.eip7623_check_gas_floor(evm, exec_result, init_and_floor_gas);
+            self.reimburse_caller(evm, exec_result)?;
+        } else {
+            evm.ctx().journal_mut().checkpoint_commit();
+        }
+        Ok(())
+    }
+
+    fn has_reserve_violation(
+        &self,
+        evm: &mut EVM,
+        checkpoint: JournalCheckpoint,
+    ) -> Result<bool, ERROR> {
+        // The journal helper excludes top-level transaction.value and ordinary contract debits.
+        // Only surviving value movement from an EIP-7702 state context reaches this loop.
+        let candidates =
+            evm.ctx_ref().journal().delegated_debits_since(checkpoint, evm.ctx_ref().tx());
+        if !candidates.is_empty() {
+            counter!("grevm.reserve_debit_candidates").increment(candidates.len() as u64);
+        }
+        for candidate in candidates {
+            let future_cost = self.planner.required_after(self.txid, candidate.address);
+            if future_cost.is_zero() {
+                continue;
+            }
+            // Never demand money the account did not have before delegated execution. If it was
+            // already below the conservative future-cost sum, delegated execution may not make
+            // that shortage worse, but unrelated filtering remains outside this policy.
+            let required = candidate.balance_before.min(future_cost);
+            if candidate.final_balance < required {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+fn reserve_violation_result(mut gas: revm::interpreter::Gas) -> FrameResult {
+    // Preserve the gas spent by the attempted execution, but discard its execution-state refund
+    // and output. The caller reapplies the checkpoint-independent authorization refund before
+    // reimbursement.
+    gas.set_refund(0);
+    FrameResult::Call(CallOutcome::new(
+        InterpreterResult { result: InstructionResult::Revert, output: Bytes::new(), gas },
+        0..0,
+    ))
+}
+
+fn reapply_create_sender_nonce<EVM, ERROR>(evm: &mut EVM) -> Result<(), ERROR>
+where
+    EVM: EvmTr<Context: ContextTr<Tx = TxEnv, Journal: JournalTr<State = EvmState>>>,
+    ERROR: EvmTrError<EVM>,
+{
+    // Reproduce the nonce bump normally performed by revm's top-level CREATE frame. It must be a
+    // journaled mutation so a surrounding transaction/error rollback still has correct semantics.
+    let sender = evm.ctx_ref().tx().caller();
+    let account = evm.ctx().journal_mut().load_account(sender)?;
+    let Some(new_nonce) = account.data.info.nonce.checked_add(1) else {
+        return Err(InvalidTransaction::NonceOverflowInTransaction.into());
+    };
+    account.data.info.nonce = new_nonce;
+    evm.ctx().journal_mut().nonce_bump_journal_entry(sender);
+    Ok(())
+}

--- a/src/delegated_safety/instructions.rs
+++ b/src/delegated_safety/instructions.rs
@@ -1,0 +1,53 @@
+use revm::{
+    bytecode::opcode::{CREATE, CREATE2},
+    handler::instructions::EthInstructions,
+    interpreter::{
+        Host, Instruction, InstructionContext, InstructionResult,
+        instructions::contract,
+        interpreter::EthInterpreter,
+        interpreter_types::{InputsTr, InterpreterTypes, RuntimeFlag},
+    },
+};
+use revm_primitives::hardfork::SpecId;
+
+/// Mainnet instructions with grevm-local CREATE/CREATE2 delegated-context guard.
+pub(crate) fn gravity_instructions<CTX>() -> EthInstructions<EthInterpreter, CTX>
+where
+    CTX: Host,
+{
+    let mut instructions = EthInstructions::new_mainnet();
+    instructions.insert_instruction(CREATE, Instruction::new(guarded_create::<_, false, _>, 0));
+    instructions.insert_instruction(CREATE2, Instruction::new(guarded_create::<_, true, _>, 0));
+    instructions
+}
+
+fn guarded_create<WIRE: InterpreterTypes, const IS_CREATE2: bool, H: Host + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    if context.interpreter.runtime_flag.is_static() {
+        context.interpreter.halt(InstructionResult::StateChangeDuringStaticCall);
+        return;
+    }
+
+    if IS_CREATE2 && !context.interpreter.runtime_flag.spec_id().is_enabled_in(SpecId::PETERSBURG) {
+        context.interpreter.halt(InstructionResult::NotActivated);
+        return;
+    }
+
+    // `target_address` is the account owning this execution context. For a 7702 call it remains
+    // the delegated EOA even though the interpreter executes bytecode loaded from its delegate.
+    let recipient = context.interpreter.input.target_address();
+    let Some(load) = context.host.load_account_delegated(recipient) else {
+        context.interpreter.halt(InstructionResult::FatalExternalError);
+        return;
+    };
+
+    // `Some(coldness)` means the target has an EIP-7702 delegation designator; the boolean itself
+    // only reports whether loading the delegate was cold and is irrelevant to this policy.
+    if load.is_delegate_account_cold.is_some() {
+        context.interpreter.halt(InstructionResult::NotActivated);
+        return;
+    }
+
+    contract::create::<WIRE, IS_CREATE2, H>(context);
+}

--- a/src/delegated_safety/mod.rs
+++ b/src/delegated_safety/mod.rs
@@ -1,0 +1,15 @@
+//! Grevm-local EIP-7702 delegated execution safety.
+//!
+//! This module intentionally builds on upstream revm extension points instead of forking revm:
+//! custom instructions block CREATE/CREATE2 in delegated execution contexts, and a transaction
+//! handler prevents delegated execution from consuming the conservative cost of later sender
+//! transactions.
+
+mod handler;
+mod instructions;
+mod reserve;
+
+pub(crate) use handler::{BeneficiaryMode, GrevmHandler, ReserveMode};
+pub(crate) use instructions::gravity_instructions;
+pub use reserve::DelegatedSafetyConfig;
+pub(crate) use reserve::{ReserveJournalExt, ReservePlanner};

--- a/src/delegated_safety/reserve.rs
+++ b/src/delegated_safety/reserve.rs
@@ -1,0 +1,527 @@
+use crate::TxId;
+use ahash::AHashMap as HashMap;
+use dashmap::DashMap;
+use metrics::{counter, histogram};
+use revm::Database;
+use revm_context::{Journal, JournalEntry, Transaction, TxEnv, journaled_state::JournalCheckpoint};
+use revm_primitives::{Address, TxKind, U256};
+use std::{
+    sync::{Arc, OnceLock},
+    time::Instant,
+};
+
+/// Chain-controlled switches for the two EIP-7702 protections.
+///
+/// The switches are independent because delegated CREATE changes an EOA's nonce, while the
+/// balance guard handles value movement that admission filtering cannot see without execution.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DelegatedSafetyConfig {
+    /// Rejects CREATE and CREATE2 in an EIP-7702 delegated account's execution context.
+    pub forbid_delegated_create: bool,
+    /// Prevents delegated execution from consuming funds needed by later transactions.
+    pub reserve_delegated_balance: bool,
+}
+
+impl DelegatedSafetyConfig {
+    /// Disables both protections and preserves upstream revm semantics.
+    pub const fn disabled() -> Self {
+        Self { forbid_delegated_create: false, reserve_delegated_balance: false }
+    }
+
+    /// Enables only the delegated CREATE/CREATE2 guard.
+    pub const fn create_only() -> Self {
+        Self { forbid_delegated_create: true, reserve_delegated_balance: false }
+    }
+
+    /// Enables only delegated balance protection.
+    pub const fn reserve_only() -> Self {
+        Self { forbid_delegated_create: false, reserve_delegated_balance: true }
+    }
+
+    /// Enables both protections.
+    pub const fn enabled() -> Self {
+        Self { forbid_delegated_create: true, reserve_delegated_balance: true }
+    }
+}
+
+/// Lazily computes the conservative cost of one account's later block transactions.
+///
+/// The first query builds one lightweight `caller -> txids` index. A queried account then gets
+/// one suffix-sum array; accounts that never transfer value from delegated execution pay no U256
+/// calculation or per-account allocation.
+#[derive(Debug)]
+pub(crate) struct ReservePlanner {
+    /// Transactions in consensus order. `TxId` is an index into this vector.
+    txs: Arc<Vec<TxEnv>>,
+    /// `caller -> ascending TxId list`, initialized by one O(block size) scan.
+    sender_index: OnceLock<HashMap<Address, Vec<TxId>>>,
+    /// Independently initialized account suffixes shared by parallel workers.
+    schedules: DashMap<Address, Arc<OnceLock<AccountReserveSchedule>>>,
+}
+
+/// Suffix sums for the transactions sent by one account.
+///
+/// ```text
+/// block order       ... T3(A) ... T8(A) ... T11(A) ...
+/// txids                   3         8          11
+/// cost_from          C3+C8+C11   C8+C11       C11
+///
+/// Ci = Ti.max_balance_spending()
+/// ```
+///
+/// `required_after(i)` returns the `cost_from` entry for A's first transaction strictly after
+/// `i`. Summing maximum costs is intentionally conservative and keeps the policy aligned with
+/// revm's upfront balance check without recreating gravity-reth's execution simulation.
+#[derive(Clone, Debug, Default)]
+struct AccountReserveSchedule {
+    /// Strictly increasing transaction IDs whose top-level caller is this account.
+    txids: Vec<TxId>,
+    /// Saturating `max_balance_spending()` suffix sums aligned with `txids`.
+    cost_from: Vec<U256>,
+}
+
+impl ReservePlanner {
+    pub(crate) fn new(txs: Arc<Vec<TxEnv>>) -> Self {
+        Self { txs, sender_index: OnceLock::new(), schedules: DashMap::new() }
+    }
+
+    /// Returns the conservative cost of `address`'s transactions strictly after `txid`.
+    ///
+    /// A malformed transaction whose own maximum cost overflows is treated as `U256::MAX`.
+    /// Suffix addition also saturates. The reserve policy therefore remains conservative without
+    /// introducing a second block-fatal error path for a future transaction that normal
+    /// validation/filtering will reject.
+    pub(crate) fn required_after(&self, txid: TxId, address: Address) -> U256 {
+        counter!("grevm.reserve_query_count").increment(1);
+        let Some(txids) = self.sender_index().get(&address) else {
+            return U256::ZERO;
+        };
+        if txids.partition_point(|candidate| *candidate <= txid) == txids.len() {
+            return U256::ZERO;
+        }
+
+        let cell =
+            self.schedules.entry(address).or_insert_with(|| Arc::new(OnceLock::new())).clone();
+        let schedule = cell.get_or_init(|| {
+            let start = Instant::now();
+            counter!("grevm.reserve_schedule_build_count").increment(1);
+            let schedule = self.build_schedule(txids);
+            histogram!("grevm.reserve_schedule_build_time")
+                .record(start.elapsed().as_nanos() as f64);
+            schedule
+        });
+        schedule.required_after(txid)
+    }
+
+    fn sender_index(&self) -> &HashMap<Address, Vec<TxId>> {
+        self.sender_index.get_or_init(|| {
+            let start = Instant::now();
+            let mut index = HashMap::new();
+            for (txid, tx) in self.txs.iter().enumerate() {
+                index.entry(tx.caller).or_insert_with(Vec::new).push(txid);
+            }
+            counter!("grevm.reserve_index_build_count").increment(1);
+            histogram!("grevm.reserve_index_build_time").record(start.elapsed().as_nanos() as f64);
+            index
+        })
+    }
+
+    fn build_schedule(&self, txids: &[TxId]) -> AccountReserveSchedule {
+        let mut schedule = AccountReserveSchedule {
+            txids: txids.to_vec(),
+            cost_from: vec![U256::ZERO; txids.len()],
+        };
+        let mut suffix = U256::ZERO;
+
+        for (index, txid) in txids.iter().copied().enumerate().rev() {
+            let cost = self.txs[txid].max_balance_spending().unwrap_or(U256::MAX);
+            suffix = suffix.saturating_add(cost);
+            schedule.cost_from[index] = suffix;
+        }
+
+        schedule
+    }
+
+    #[cfg(test)]
+    fn is_initialized(&self) -> bool {
+        self.sender_index.get().is_some()
+    }
+
+    #[cfg(test)]
+    fn initialized_accounts(&self) -> usize {
+        self.schedules.len()
+    }
+}
+
+impl AccountReserveSchedule {
+    fn required_after(&self, txid: TxId) -> U256 {
+        match self.txids.partition_point(|candidate| *candidate <= txid) {
+            index if index < self.cost_from.len() => self.cost_from[index],
+            _ => U256::ZERO,
+        }
+    }
+}
+
+/// One delegated account whose surviving execution debit needs a reserve check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DelegatedDebit {
+    /// EIP-7702 delegation-designator account that lost balance.
+    pub(crate) address: Address,
+    /// Balance immediately before its first surviving protected debit in this transaction.
+    ///
+    /// This deliberately includes value credited earlier in the same delegated execution. Once
+    /// those funds become spendable by the delegated account, protecting them before a later debit
+    /// gives future block transactions the strongest conservative funding guarantee.
+    pub(crate) balance_before: U256,
+    /// Balance after execution and unused-gas reimbursement.
+    pub(crate) final_balance: U256,
+}
+
+/// Finds real balance debits made from delegated execution using revm's surviving journal.
+///
+/// A standard EVM value-moving operation debits its current state account. Therefore, after
+/// excluding the root transaction value transfer, a debit whose source still contains an
+/// EIP-7702 designator came from that delegated account's execution context. Reverted inner-frame
+/// entries are already absent from the journal.
+pub(crate) trait ReserveJournalExt {
+    fn delegated_debits_since(
+        &self,
+        checkpoint: JournalCheckpoint,
+        tx: &TxEnv,
+    ) -> Vec<DelegatedDebit>;
+}
+
+impl<DB: Database> ReserveJournalExt for Journal<DB> {
+    fn delegated_debits_since(
+        &self,
+        checkpoint: JournalCheckpoint,
+        tx: &TxEnv,
+    ) -> Vec<DelegatedDebit> {
+        debug_assert!(checkpoint.journal_i <= self.inner.journal.len());
+        let entries = &self.inner.journal;
+        let mut root_value_pending = !tx.value.is_zero();
+        let mut first_debit = HashMap::<Address, usize>::new();
+
+        for (entry_index, entry) in entries.iter().enumerate().skip(checkpoint.journal_i) {
+            if root_value_pending && is_root_value_transfer(entry, tx) {
+                // `filter_invalid_txs` already sees transaction.value. A delegated EOA may send
+                // an ordinary transaction without executing its own delegated code, so this
+                // single top-level transfer must not become a reserve candidate.
+                root_value_pending = false;
+                continue;
+            }
+
+            let source = match entry {
+                JournalEntry::BalanceTransfer { from, to, balance }
+                    if from != to && !balance.is_zero() =>
+                {
+                    Some(*from)
+                }
+                JournalEntry::AccountDestroyed { address, had_balance, .. }
+                    if !had_balance.is_zero() =>
+                {
+                    Some(*address)
+                }
+                _ => None,
+            };
+            let Some(source) = source else {
+                continue;
+            };
+            let is_delegated = self
+                .inner
+                .state
+                .get(&source)
+                .and_then(|account| account.info.code.as_ref())
+                .is_some_and(|code| code.is_eip7702());
+            if is_delegated {
+                first_debit.entry(source).or_insert(entry_index);
+            }
+        }
+
+        first_debit
+            .into_iter()
+            .filter_map(|(address, entry_index)| {
+                let final_balance = self.inner.state.get(&address)?.info.balance;
+                Some(DelegatedDebit {
+                    address,
+                    balance_before: balance_before_entry(
+                        entries,
+                        entry_index,
+                        address,
+                        final_balance,
+                    ),
+                    final_balance,
+                })
+            })
+            .collect()
+    }
+}
+
+fn is_root_value_transfer(entry: &JournalEntry, tx: &TxEnv) -> bool {
+    let JournalEntry::BalanceTransfer { from, to, balance } = entry else {
+        return false;
+    };
+    if *from != tx.caller || *balance != tx.value {
+        return false;
+    }
+    match tx.kind {
+        TxKind::Call(target) => *to == target,
+        // The root CREATE transfer precedes init-code execution, so the first matching transfer
+        // from the transaction caller is unambiguously the filter-visible transaction value.
+        TxKind::Create => true,
+    }
+}
+
+/// Reconstructs the balance before `entry_index` by undoing the surviving balance journal.
+///
+/// ```text
+/// balance before first delegated debit
+///          | debit | ... credits/debits ... | reimburse | final balance
+///          <---------------- reverse journal ----------------'
+/// ```
+///
+/// Saturating arithmetic is defensive only; valid revm journal entries reverse exactly.
+fn balance_before_entry(
+    entries: &[JournalEntry],
+    entry_index: usize,
+    address: Address,
+    final_balance: U256,
+) -> U256 {
+    let mut balance = final_balance;
+    for entry in entries[entry_index..].iter().rev() {
+        match entry {
+            JournalEntry::BalanceTransfer { from, to, balance: value } => {
+                if *from == address && *to != address {
+                    balance = balance.saturating_add(*value);
+                } else if *to == address && *from != address {
+                    balance = balance.saturating_sub(*value);
+                }
+            }
+            JournalEntry::AccountDestroyed { address: destroyed, target, had_balance, .. } => {
+                if *destroyed == address {
+                    balance = balance.saturating_add(*had_balance);
+                } else if *target == address {
+                    balance = balance.saturating_sub(*had_balance);
+                }
+            }
+            JournalEntry::BalanceChange { address: changed, old_balance }
+                if *changed == address =>
+            {
+                balance = *old_balance;
+            }
+            _ => {}
+        }
+    }
+    balance
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm_context::{JournalTr, journal::entry::SelfdestructionRevertStatus};
+    use revm_database::EmptyDB;
+    use revm_primitives::address;
+    use revm_state::{Account, Bytecode};
+
+    fn tx(caller: Address, value: u64, gas_limit: u64, gas_price: u128) -> TxEnv {
+        TxEnv {
+            caller,
+            kind: TxKind::Call(Address::ZERO),
+            value: U256::from(value),
+            gas_limit,
+            gas_price,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn planner_is_lazy_and_builds_only_queried_accounts() {
+        let a = address!("00000000000000000000000000000000000000aa");
+        let b = address!("00000000000000000000000000000000000000bb");
+        let planner =
+            ReservePlanner::new(Arc::new(vec![tx(a, 0, 10, 2), tx(b, 0, 20, 3), tx(a, 0, 30, 4)]));
+
+        assert!(!planner.is_initialized());
+        assert_eq!(planner.required_after(0, a), U256::from(120));
+        assert!(planner.is_initialized());
+        assert_eq!(planner.initialized_accounts(), 1);
+        assert_eq!(planner.required_after(0, b), U256::from(60));
+        assert_eq!(planner.initialized_accounts(), 2);
+    }
+
+    #[test]
+    fn suffix_accumulates_every_future_maximum_cost() {
+        let caller = address!("00000000000000000000000000000000000000aa");
+        let planner =
+            ReservePlanner::new(Arc::new(vec![tx(caller, 100, 10, 20), tx(caller, 7, 5, 20)]));
+
+        assert_eq!(planner.required_after(0, caller), U256::from(107));
+        let schedule = planner.schedules.get(&caller).unwrap();
+        let schedule = schedule.get().unwrap();
+        assert_eq!(schedule.cost_from[0], U256::from(407));
+    }
+
+    #[test]
+    fn queries_use_logical_txid_not_first_query_order() {
+        let caller = address!("00000000000000000000000000000000000000aa");
+        let txs = (0..9).map(|_| tx(caller, 0, 1, 1)).collect();
+        let planner = ReservePlanner::new(Arc::new(txs));
+
+        assert_eq!(planner.required_after(7, caller), U256::from(1));
+        assert_eq!(planner.required_after(2, caller), U256::from(6));
+        assert_eq!(planner.required_after(8, caller), U256::ZERO);
+    }
+
+    #[test]
+    fn planner_saturates_malformed_or_oversized_suffixes() {
+        let caller = address!("00000000000000000000000000000000000000aa");
+        let planner = ReservePlanner::new(Arc::new(vec![
+            tx(Address::ZERO, 0, 1, 1),
+            tx(caller, 0, u64::MAX, u128::MAX),
+            tx(caller, 0, 1, 1),
+        ]));
+
+        assert_eq!(planner.required_after(0, caller), U256::MAX);
+    }
+
+    #[test]
+    fn journal_selects_only_delegated_debits_and_excludes_root_value() {
+        let delegated = address!("00000000000000000000000000000000000000aa");
+        let ordinary = address!("00000000000000000000000000000000000000bb");
+        let receiver = address!("00000000000000000000000000000000000000cc");
+        let mut journal = Journal::<EmptyDB>::new(EmptyDB::default());
+        let mut delegated_account = Account::default();
+        delegated_account.info.balance = U256::from(100);
+        delegated_account.info.code = Some(Bytecode::new_eip7702(receiver));
+        journal.inner.state.insert(delegated, delegated_account);
+        let mut ordinary_account = Account::default();
+        ordinary_account.info.balance = U256::from(100);
+        journal.inner.state.insert(ordinary, ordinary_account);
+        journal.inner.state.insert(receiver, Account::default());
+
+        let checkpoint = journal.checkpoint();
+        journal.inner.journal.extend([
+            // Filter-visible root transaction value: excluded even though caller is delegated.
+            JournalEntry::BalanceTransfer {
+                from: delegated,
+                to: ordinary,
+                balance: U256::from(10),
+            },
+            // Ordinary contract debit: not a delegated execution context.
+            JournalEntry::BalanceTransfer { from: ordinary, to: receiver, balance: U256::from(20) },
+            // Delegated execution debit: the only candidate.
+            JournalEntry::BalanceTransfer {
+                from: delegated,
+                to: receiver,
+                balance: U256::from(30),
+            },
+        ]);
+        journal.inner.state.get_mut(&delegated).unwrap().info.balance = U256::from(60);
+        journal.inner.state.get_mut(&ordinary).unwrap().info.balance = U256::from(90);
+        journal.inner.state.get_mut(&receiver).unwrap().info.balance = U256::from(50);
+        let root_tx = TxEnv {
+            caller: delegated,
+            kind: TxKind::Call(ordinary),
+            value: U256::from(10),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            journal.delegated_debits_since(checkpoint, &root_tx),
+            vec![DelegatedDebit {
+                address: delegated,
+                balance_before: U256::from(90),
+                final_balance: U256::from(60),
+            }]
+        );
+    }
+
+    #[test]
+    fn selfdestruct_and_later_credit_restore_the_pre_debit_balance() {
+        let delegated = address!("00000000000000000000000000000000000000aa");
+        let receiver = address!("00000000000000000000000000000000000000bb");
+        let mut journal = Journal::<EmptyDB>::new(EmptyDB::default());
+        let mut account = Account::default();
+        account.info.code = Some(Bytecode::new_eip7702(receiver));
+        account.info.balance = U256::from(5);
+        journal.inner.state.insert(delegated, account);
+        journal.inner.state.insert(receiver, Account::default());
+        let checkpoint = journal.checkpoint();
+        journal.inner.journal.extend([
+            JournalEntry::AccountDestroyed {
+                address: delegated,
+                target: receiver,
+                destroyed_status: SelfdestructionRevertStatus::GloballySelfdestroyed,
+                had_balance: U256::from(5),
+            },
+            JournalEntry::BalanceTransfer { from: receiver, to: delegated, balance: U256::from(2) },
+        ]);
+        journal.inner.state.get_mut(&delegated).unwrap().info.balance = U256::from(2);
+        journal.inner.state.get_mut(&receiver).unwrap().info.balance = U256::from(3);
+
+        assert_eq!(
+            journal.delegated_debits_since(checkpoint, &TxEnv::default()),
+            vec![DelegatedDebit {
+                address: delegated,
+                balance_before: U256::from(5),
+                final_balance: U256::from(2),
+            }]
+        );
+    }
+
+    #[test]
+    fn credit_before_first_debit_is_included_in_the_protected_balance() {
+        let delegated = address!("00000000000000000000000000000000000000aa");
+        let funder = address!("00000000000000000000000000000000000000bb");
+        let receiver = address!("00000000000000000000000000000000000000cc");
+        let mut journal = Journal::<EmptyDB>::new(EmptyDB::default());
+        let mut account = Account::default();
+        account.info.code = Some(Bytecode::new_eip7702(receiver));
+        account.info.balance = U256::from(100);
+        journal.inner.state.insert(delegated, account);
+        journal.inner.state.insert(funder, Account::default());
+        journal.inner.state.insert(receiver, Account::default());
+        let checkpoint = journal.checkpoint();
+        journal.inner.journal.extend([
+            // The delegated account first receives 1,000, then spends exactly that credit.
+            JournalEntry::BalanceTransfer {
+                from: funder,
+                to: delegated,
+                balance: U256::from(1_000),
+            },
+            JournalEntry::BalanceTransfer {
+                from: delegated,
+                to: receiver,
+                balance: U256::from(1_000),
+            },
+        ]);
+        journal.inner.state.get_mut(&delegated).unwrap().info.balance = U256::from(100);
+
+        assert_eq!(
+            journal.delegated_debits_since(checkpoint, &TxEnv::default()),
+            vec![DelegatedDebit {
+                address: delegated,
+                balance_before: U256::from(1_100),
+                final_balance: U256::from(100),
+            }]
+        );
+    }
+
+    #[test]
+    fn reverted_native_entries_need_no_second_undo_stack() {
+        let delegated = address!("00000000000000000000000000000000000000aa");
+        let receiver = address!("00000000000000000000000000000000000000bb");
+        let mut journal = Journal::<EmptyDB>::new(EmptyDB::default());
+        let mut sender = Account::default();
+        sender.info.balance = U256::from(1);
+        sender.info.code = Some(Bytecode::new_eip7702(receiver));
+        journal.inner.state.insert(delegated, sender);
+        journal.inner.state.insert(receiver, Account::default());
+        let execution = journal.checkpoint();
+        let inner = journal.checkpoint();
+        assert_eq!(journal.transfer(delegated, receiver, U256::from(1)).unwrap(), None);
+        journal.checkpoint_revert(inner);
+
+        assert!(journal.delegated_debits_since(execution, &TxEnv::default()).is_empty());
+    }
+}

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -1,4 +1,4 @@
-use crate::{LocationAndType, TxId, fork_join_util, tx_dependency::TxDependency};
+use crate::{LocationAndType, TxId, tx_dependency::TxDependency, utils::fork_join_util};
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use revm::primitives::{
     Address, B256, Bytes, TxKind, U256, alloy_primitives::U160, keccak256, ruint::UintTryFrom,
@@ -12,13 +12,13 @@ use std::{cell::UnsafeCell, cmp::max, sync::Arc};
 /// and methods for updating transaction states based on contract interactions.
 #[allow(dead_code)]
 enum ContractType {
-    UNKNOWN,
+    Unknown,
     ERC20,
 }
 
 /// Represents different types of contracts. Currently, only ERC20 is supported.
 enum ERC20Function {
-    UNKNOWN,
+    Unknown,
     Allowance,
     Approve,
     BalanceOf,
@@ -46,7 +46,7 @@ impl From<u32> for ERC20Function {
             0x18160ddd => ERC20Function::TotalSupply,
             0xa9059cbb => ERC20Function::Transfer,
             0x23b872dd => ERC20Function::TransferFrom,
-            _ => ERC20Function::UNKNOWN,
+            _ => ERC20Function::Unknown,
         }
     }
 }
@@ -220,7 +220,7 @@ impl ParallelExecutionHints {
         if code.is_none() && data.is_empty() {
             return false;
         }
-        if data.len() < 4 || (data.len() - 4) % 32 != 0 {
+        if data.len() < 4 || !(data.len() - 4).is_multiple_of(32) {
             // Invalid tx, or tx that triggers fallback CALL
             return false;
         }
@@ -277,7 +277,7 @@ impl ParallelExecutionHints {
                     return false;
                 }
             },
-            ContractType::UNKNOWN => {
+            ContractType::Unknown => {
                 return false;
             }
         }
@@ -291,11 +291,11 @@ impl ParallelExecutionHints {
         if data.len() >= 4 {
             let func_id = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
             match ERC20Function::from(func_id) {
-                ERC20Function::UNKNOWN => ContractType::UNKNOWN,
+                ERC20Function::Unknown => ContractType::Unknown,
                 _ => ContractType::ERC20,
             }
         } else {
-            ContractType::UNKNOWN
+            ContractType::Unknown
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,7 @@
 //! ## Concurrency
 //!
 //! Grevm automatically determines the optimal level of concurrency based on the available CPU
-//! cores, but this can be customized as needed. The `CONCURRENT_LEVEL` static variable provides the
-//! default concurrency level.
+//! cores. Integrations can override it through [`GrevmConfig::concurrency_level`].
 //!
 //! ## Error Handling
 //!
@@ -17,214 +16,30 @@
 //! transaction ID and the underlying EVM error. This allows for precise debugging and error
 //! reporting.
 mod async_commit;
+mod bundle;
+mod cache_db;
+mod config;
+mod delegated_safety;
 mod hint;
+mod model;
+mod outcome;
 mod parallel_state;
 mod scheduler;
-mod storage;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 mod tx_dependency;
 mod utils;
 
-use ahash::{AHashMap as HashMap, AHashSet as HashSet};
-use lazy_static::lazy_static;
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-pub use revm_context::result::InvalidTransaction;
-use revm_context::result::{EVMError, ExecutionResult, ResultAndState};
-use revm_primitives::{Address, B256, U256};
-use revm_state::{AccountInfo, Bytecode};
-use std::{cmp::min, thread};
+pub(crate) use model::{
+    AbortReason, AccountBasic, LocationAndType, MVMemory, MemoryEntry, MemoryValue, ReadVersion,
+    Task, TransactionResult, TransactionStatus, TxId, TxState, TxVersion,
+};
 
-lazy_static! {
-    static ref CONCURRENT_LEVEL: usize =
-        thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
-    static ref FALLBACK_SEQUENTIAL: bool =
-        std::env::var("GREVM_FALLBACK_SEQUENTIAL").map_or(false, |s| s.parse().unwrap_or(false));
-    /// Minimum number of transactions in a block to run the parallel scheduler; smaller blocks
-    /// fall back to sequential execution. Defaults to 64 but can be overridden via the
-    /// `GREVM_MIN_PARALLEL_TXS` environment variable. Set it to `0` to force the parallel path
-    /// even for tiny blocks (useful when replaying small mainnet blocks to validate parallelism).
-    static ref MIN_PARALLEL_TXS: usize =
-        std::env::var("GREVM_MIN_PARALLEL_TXS").map_or(64, |s| s.parse().unwrap_or(64));
-}
-
-type TxId = usize;
-
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
-enum TransactionStatus {
-    #[default]
-    Initial,
-    Executing,
-    Executed,
-    Validating,
-    Unconfirmed,
-    Conflict,
-    Finality,
-}
-
-#[derive(Debug, Default)]
-struct TxState {
-    pub status: TransactionStatus,
-    pub incarnation: usize,
-    pub dependency: Option<TxId>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-struct TxVersion {
-    pub txid: TxId,
-    pub incarnation: usize,
-}
-
-impl TxVersion {
-    pub(crate) fn new(txid: TxId, incarnation: usize) -> Self {
-        Self { txid, incarnation }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-enum ReadVersion {
-    MvMemory(TxVersion),
-    Storage,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct AccountBasic {
-    /// The balance of the account.
-    pub balance: U256,
-    /// The nonce of the account.
-    pub nonce: u64,
-    pub code_hash: Option<B256>,
-}
-
-#[derive(Debug, Clone)]
-enum MemoryValue {
-    Basic(AccountInfo),
-    /// An account's code set by a transaction, plus whether that transaction *created* the account
-    /// (`CREATE`/`CREATE2`), which clears its storage. `false` for an EIP-7702 (re)delegation,
-    /// which only re-points code and preserves the account's pre-existing storage.
-    Code(Bytecode, bool),
-    Storage(U256),
-    SelfDestructed,
-}
-
-#[derive(Debug, Clone)]
-struct MemoryEntry {
-    incarnation: usize,
-    data: MemoryValue,
-    estimate: bool,
-}
-
-impl MemoryEntry {
-    pub(crate) fn new(incarnation: usize, data: MemoryValue, estimate: bool) -> Self {
-        Self { incarnation, data, estimate }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-enum LocationAndType {
-    Basic(Address),
-
-    Storage(Address, U256),
-
-    Code(Address),
-}
-
-struct TransactionResult<DBError> {
-    pub read_set: HashMap<LocationAndType, ReadVersion>,
-    pub write_set: HashSet<LocationAndType>,
-    pub execute_result: Result<ResultAndState, EVMError<DBError>>,
-}
-
-#[derive(Clone, Debug)]
-enum Task {
-    Execution(TxVersion),
-    Validation(TxVersion),
-}
-
-impl Default for Task {
-    fn default() -> Self {
-        Task::Execution(TxVersion::new(0, 0))
-    }
-}
-
-enum AbortReason<DBError> {
-    /// A fatal EVM error produced while executing this transaction. The error itself remains in
-    /// `Scheduler::tx_results`.
-    FatalEvmError(TxId),
-    /// A commit error is not stored in `Scheduler::tx_results`, so the abort reason carries the
-    /// complete error instead of trying to recover it from an execution result.
-    CommitError(GrevmError<DBError>),
-    /// An invariant of the parallel scheduler was violated before the current transaction was
-    /// committed. The committed prefix is still valid, so execution can resume sequentially.
-    ParallelError {
-        txid: TxId,
-        message: &'static str,
-    },
-    #[allow(dead_code)]
-    SelfDestructed,
-    FallbackSequential,
-}
-
-/// Final outcome for one transaction in block order.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TxExecutionOutcome {
-    /// The transaction executed normally, including EVM reverts and halts.
-    Executed(ExecutionResult),
-    /// The transaction was invalid at the committed state and was applied as a no-op. The exact
-    /// revm validation error is forwarded to the consumer for protocol-specific encoding.
-    Skipped(InvalidTransaction),
-}
-
-/// Grevm error type.
-#[derive(Debug, Clone)]
-pub struct GrevmError<DBError> {
-    /// The transaction id that caused the error.
-    pub txid: TxId,
-    /// The error that occurred.
-    pub error: EVMError<DBError>,
-}
-
-/// Utility function for parallel execution using fork-join pattern.
-///
-/// This function divides the work into partitions and executes the provided closure `f`
-/// in parallel across multiple threads. The number of partitions can be specified, or it
-/// will default to twice the number of CPU cores plus one.
-///
-/// # Arguments
-///
-/// * `num_elements` - The total number of elements to process.
-/// * `num_partitions` - Optional number of partitions to divide the work into.
-/// * `f` - A closure that takes three arguments: the start index, the end index, and the partition
-///   index.
-///
-/// # Example
-///
-/// ```
-/// use grevm::fork_join_util;
-/// fork_join_util(100, Some(4), |start, end, index| {
-///     println!("Partition {}: processing elements {} to {}", index, start, end);
-/// });
-/// ```
-pub fn fork_join_util<'scope, F>(num_elements: usize, num_partitions: Option<usize>, f: F)
-where
-    F: Fn(usize, usize, usize) + Send + Sync + 'scope,
-{
-    if num_elements == 0 {
-        return;
-    }
-    let parallel_cnt = num_partitions.unwrap_or(*CONCURRENT_LEVEL);
-    let remaining = num_elements % parallel_cnt;
-    let chunk_size = num_elements / parallel_cnt;
-    (0..parallel_cnt).into_par_iter().for_each(|index| {
-        let start_pos = chunk_size * index + min(index, remaining);
-        let mut end_pos = start_pos + chunk_size;
-        if index < remaining {
-            end_pos += 1;
-        }
-        f(start_pos, end_pos, index);
-    });
-}
-
+pub use bundle::{ParallelBundleState, ParallelTakeBundle};
+pub use config::GrevmConfig;
+pub use delegated_safety::DelegatedSafetyConfig;
+pub use outcome::{GrevmError, TxExecutionOutcome};
 pub use parallel_state::{ParallelCacheState, ParallelState};
+pub use revm_context::result::InvalidTransaction;
 pub use scheduler::Scheduler;
-pub use storage::{ParallelBundleState, ParallelTakeBundle};
+pub use utils::fork_join_util;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,113 @@
+use crate::GrevmError;
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
+use dashmap::DashMap;
+use revm_context::result::{EVMError, ResultAndState};
+use revm_primitives::{Address, B256, U256};
+use revm_state::{AccountInfo, Bytecode};
+use std::collections::BTreeMap;
+
+pub(crate) type TxId = usize;
+pub(crate) type MVMemory = DashMap<LocationAndType, BTreeMap<TxId, MemoryEntry>>;
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub(crate) enum TransactionStatus {
+    #[default]
+    Initial,
+    Executing,
+    Executed,
+    Validating,
+    Unconfirmed,
+    Conflict,
+    Finality,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TxState {
+    pub(crate) status: TransactionStatus,
+    pub(crate) incarnation: usize,
+    pub(crate) dependency: Option<TxId>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TxVersion {
+    pub(crate) txid: TxId,
+    pub(crate) incarnation: usize,
+}
+
+impl TxVersion {
+    pub(crate) fn new(txid: TxId, incarnation: usize) -> Self {
+        Self { txid, incarnation }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ReadVersion {
+    MvMemory(TxVersion),
+    Storage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AccountBasic {
+    pub(crate) balance: U256,
+    pub(crate) nonce: u64,
+    pub(crate) code_hash: Option<B256>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum MemoryValue {
+    Basic(AccountInfo),
+    /// Code plus whether the transaction created the account and therefore cleared its storage.
+    Code(Bytecode, bool),
+    Storage(U256),
+    SelfDestructed,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MemoryEntry {
+    pub(crate) incarnation: usize,
+    pub(crate) data: MemoryValue,
+    pub(crate) estimate: bool,
+}
+
+impl MemoryEntry {
+    pub(crate) fn new(incarnation: usize, data: MemoryValue, estimate: bool) -> Self {
+        Self { incarnation, data, estimate }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum LocationAndType {
+    Basic(Address),
+    Storage(Address, U256),
+    Code(Address),
+}
+
+pub(crate) struct TransactionResult<DBError> {
+    pub(crate) read_set: HashMap<LocationAndType, ReadVersion>,
+    pub(crate) write_set: HashSet<LocationAndType>,
+    pub(crate) execute_result: Result<ResultAndState, EVMError<DBError>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum Task {
+    Execution(TxVersion),
+    Validation(TxVersion),
+}
+
+impl Default for Task {
+    fn default() -> Self {
+        Self::Execution(TxVersion::new(0, 0))
+    }
+}
+
+pub(crate) enum AbortReason<DBError> {
+    FatalEvmError(TxId),
+    CommitError(GrevmError<DBError>),
+    ParallelError {
+        txid: TxId,
+        message: &'static str,
+    },
+    #[allow(dead_code)]
+    SelfDestructed,
+    FallbackSequential,
+}

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -1,0 +1,20 @@
+use revm_context::result::{EVMError, ExecutionResult, InvalidTransaction};
+
+/// Final outcome for one transaction in block order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TxExecutionOutcome {
+    /// The transaction executed normally, including EVM reverts and halts.
+    Executed(ExecutionResult),
+    /// The transaction was invalid at the committed state and was applied as a no-op. The exact
+    /// revm validation error is forwarded to the consumer for protocol-specific encoding.
+    Skipped(InvalidTransaction),
+}
+
+/// Error returned when grevm cannot safely continue execution.
+#[derive(Debug, Clone)]
+pub struct GrevmError<DBError> {
+    /// Transaction index associated with the error.
+    pub txid: usize,
+    /// Underlying EVM error.
+    pub error: EVMError<DBError>,
+}

--- a/src/parallel_state.rs
+++ b/src/parallel_state.rs
@@ -51,7 +51,7 @@ impl CacheAccountInfo {
         &mut self,
         change: F,
     ) -> (T, TransitionAccount) {
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
         let previous_info = self.account.clone();
         let mut info = self.account.take().unwrap_or_default();
         let output = change(&mut info);
@@ -65,7 +65,7 @@ impl CacheAccountInfo {
             output,
             TransitionAccount {
                 info: self.account.clone(),
-                status: self.status.clone(),
+                status: self.status,
                 previous_info,
                 previous_status,
                 storage: Default::default(),
@@ -80,7 +80,7 @@ impl CacheAccountInfo {
     pub fn selfdestruct(&mut self) -> Option<TransitionAccount> {
         // account should be None after selfdestruct so we can take it.
         let previous_info = self.account.take();
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
 
         self.status = self.status.on_selfdestructed();
 
@@ -89,7 +89,7 @@ impl CacheAccountInfo {
         } else {
             Some(TransitionAccount {
                 info: None,
-                status: self.status.clone(),
+                status: self.status,
                 previous_info,
                 previous_status,
                 storage: Default::default(),
@@ -105,14 +105,14 @@ impl CacheAccountInfo {
         new_storage: StorageWithOriginalValues,
     ) -> (TransitionAccount, PlainStorage) {
         let previous_info = self.account.take();
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
 
         let new_bundle_storage = new_storage.iter().map(|(k, s)| (*k, s.present_value)).collect();
 
         self.status = self.status.on_created();
         let transition_account = TransitionAccount {
             info: Some(new_info.clone()),
-            status: self.status.clone(),
+            status: self.status,
             previous_status,
             previous_info,
             storage: new_storage,
@@ -128,7 +128,7 @@ impl CacheAccountInfo {
     pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount> {
         // Set account to None.
         let previous_info = self.account.take();
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
 
         // Set account state to Destroyed as we need to clear the storage if it exist.
         self.status = self.status.on_touched_empty_post_eip161();
@@ -143,7 +143,7 @@ impl CacheAccountInfo {
         } else {
             Some(TransitionAccount {
                 info: None,
-                status: self.status.clone(),
+                status: self.status,
                 previous_info,
                 previous_status,
                 storage: Default::default(),
@@ -157,7 +157,7 @@ impl CacheAccountInfo {
         &mut self,
         storage: StorageWithOriginalValues,
     ) -> (Option<TransitionAccount>, PlainStorage) {
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
 
         let had_no_info = self.account.as_ref().map(|info| info.is_empty()).unwrap_or_default();
         match self.status.on_touched_created_pre_eip161(had_no_info) {
@@ -175,7 +175,7 @@ impl CacheAccountInfo {
         (
             Some(TransitionAccount {
                 info: Some(AccountInfo::default()),
-                status: self.status.clone(),
+                status: self.status,
                 previous_info,
                 previous_status,
                 storage,
@@ -191,7 +191,7 @@ impl CacheAccountInfo {
         storage: StorageWithOriginalValues,
     ) -> (TransitionAccount, PlainStorage) {
         let previous_info = self.account.take();
-        let previous_status = self.status.clone();
+        let previous_status = self.status;
         let new_bundle_storage = storage.iter().map(|(k, s)| (*k, s.present_value)).collect();
 
         let had_no_nonce_and_code =
@@ -202,7 +202,7 @@ impl CacheAccountInfo {
         (
             TransitionAccount {
                 info: self.account.clone(),
-                status: self.status.clone(),
+                status: self.status,
                 previous_info,
                 previous_status,
                 storage,
@@ -254,29 +254,27 @@ impl ParallelCacheState {
         for kv in self.accounts.iter() {
             let info = kv.value();
             state.accounts.insert(
-                kv.key().clone(),
+                *kv.key(),
                 CacheAccount {
                     account: info
                         .account
                         .clone()
                         .map(|info| PlainAccount { info, storage: PlainStorage::default() }),
-                    status: info.status.clone(),
+                    status: info.status,
                 },
             );
         }
         for kv in self.contracts.iter() {
-            state.contracts.insert(kv.key().clone(), kv.value().clone());
+            state.contracts.insert(*kv.key(), kv.value().clone());
         }
         for kv in self.storage.iter() {
-            let address = kv.key().clone();
+            let address = *kv.key();
             let slots = kv.value();
-            if let Some(account) = state.accounts.get_mut(&address) {
-                if let Some(plain_account) = account.account.as_mut() {
-                    for slot_value in slots.iter() {
-                        plain_account
-                            .storage
-                            .insert(slot_value.key().clone(), slot_value.value().clone());
-                    }
+            if let Some(account) = state.accounts.get_mut(&address) &&
+                let Some(plain_account) = account.account.as_mut()
+            {
+                for slot_value in slots.iter() {
+                    plain_account.storage.insert(*slot_value.key(), *slot_value.value());
                 }
             }
         }
@@ -395,10 +393,10 @@ impl ParallelCacheState {
                 (Some(transition), Some(changed_slots))
             }
         };
-        if let Some(changed_slots) = changed_slots {
-            if !changed_slots.is_empty() {
-                self.update_storage_slot(address, changed_slots);
-            }
+        if let Some(changed_slots) = changed_slots &&
+            !changed_slots.is_empty()
+        {
+            self.update_storage_slot(address, changed_slots);
         }
         transition
     }
@@ -708,10 +706,10 @@ impl<DB: DatabaseRef> ParallelState<DB> {
     }
 
     fn db_storage(&self, address: Address, index: U256) -> Result<U256, DB::Error> {
-        if let Some(slots) = self.cache.storage.get(&address) {
-            if let Some(value) = slots.get(&index) {
-                return Ok(value.value().clone());
-            }
+        if let Some(slots) = self.cache.storage.get(&address) &&
+            let Some(value) = slots.get(&index)
+        {
+            return Ok(*value.value());
         }
         // Account is guaranteed to be loaded.
         // Note that storage from bundle is already loaded with account.
@@ -730,12 +728,12 @@ impl<DB: DatabaseRef> ParallelState<DB> {
             self.with_metrics(|| self.database.storage_ref(address, index))?
         };
         let value = if let Some(slots) = self.cache.storage.get(&address) {
-            slots.entry(index).or_insert(value).value().clone()
+            *slots.entry(index).or_insert(value).value()
         } else {
             match self.cache.storage.entry(address) {
-                Entry::Occupied(entry) => entry.get().entry(index).or_insert(value).value().clone(),
+                Entry::Occupied(entry) => *entry.get().entry(index).or_insert(value).value(),
                 Entry::Vacant(entry) => {
-                    entry.insert(Default::default()).entry(index).or_insert(value).value().clone()
+                    *entry.insert(Default::default()).entry(index).or_insert(value).value()
                 }
             }
         };

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,310 +1,41 @@
+mod context;
+mod executor;
+mod fallback;
+mod metrics;
+#[cfg(test)]
+mod tests;
+
 use crate::{
-    AbortReason, CONCURRENT_LEVEL, FALLBACK_SEQUENTIAL, GrevmError, LocationAndType,
-    MIN_PARALLEL_TXS, MemoryEntry, ParallelState, ReadVersion, Task, TransactionResult,
-    TransactionStatus, TxExecutionOutcome, TxId, TxState, TxVersion,
+    AbortReason, GrevmConfig, GrevmError, LocationAndType, MVMemory, ParallelState, ReadVersion,
+    Task, TransactionResult, TransactionStatus, TxExecutionOutcome, TxId, TxState, TxVersion,
     async_commit::{CommitGuard, StateAsyncCommit},
+    cache_db::CacheDB,
+    delegated_safety::{DelegatedSafetyConfig, ReservePlanner},
     hint::ParallelExecutionHints,
-    storage::CacheDB,
     tx_dependency::TxDependency,
-    utils::ContinuousDetectSet,
 };
+use ::metrics::histogram;
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
-use alloy_evm::{
-    EthEvm, Evm,
-    precompiles::{DynPrecompile, PrecompilesMap},
-};
-use dashmap::DashMap;
-use metrics::histogram;
-use metrics_derive::Metrics;
+use alloy_evm::precompiles::DynPrecompile;
+use context::SchedulerContext;
+use executor::{GrevmExecutor, ParallelTransactionExecutor};
+use metrics::ExecuteMetricsCollector;
 use parking_lot::Mutex;
-use revm::{
-    Context, DatabaseCommit, DatabaseRef, ExecuteEvm, MainBuilder, MainContext,
-    context::Evm as RevmEvm,
-    handler::{
-        EthFrame, EvmTr, EvmTrError, FrameResult, FrameTr, Handler, instructions::EthInstructions,
-    },
-    interpreter::{interpreter::EthInterpreter, interpreter_action::FrameInit},
-    precompile::{PrecompileSpecId, Precompiles},
-};
-use revm_context::{
-    BlockEnv, CfgEnv, ContextSetters, ContextTr, JournalTr, TxEnv,
-    result::{EVMError, HaltReason, ResultAndState},
-};
-use revm_inspector::NoOpInspector;
+use revm::DatabaseRef;
+use revm_context::{BlockEnv, CfgEnv, TxEnv, result::EVMError};
 use revm_primitives::Address;
-use revm_state::EvmState;
 
 use std::{
     cell::UnsafeCell,
     cmp::max,
-    collections::BTreeMap,
     fmt::Debug,
     sync::{
         Arc, OnceLock,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     thread,
     time::Instant,
 };
-
-pub(crate) type MVMemory = DashMap<LocationAndType, BTreeMap<TxId, MemoryEntry>>;
-
-/// The mainnet EVM context grevm executes against on the parallel path (an `EthEvm`-shaped stack).
-type GrevmCtx<'a, DB> = Context<BlockEnv, TxEnv, CfgEnv, CacheDB<'a, ParallelState<DB>>>;
-
-/// The raw revm EVM, unwrapped from alloy's `EthEvm`, so we can drive a custom [`Handler`] that
-/// skips the miner reward during execution.
-type GrevmEvm<'a, DB> = RevmEvm<
-    GrevmCtx<'a, DB>,
-    NoOpInspector,
-    EthInstructions<EthInterpreter, GrevmCtx<'a, DB>>,
-    PrecompilesMap,
-    EthFrame,
->;
-
-/// A mainnet [`Handler`] that suppresses the beneficiary (miner) reward. Instead of crediting the
-/// coinbase inside transaction execution — which would make every transaction read & write the
-/// coinbase account and thus conflict — grevm defers the reward and applies it at commit time (see
-/// [`crate::async_commit::StateAsyncCommit::compute_reward`]). This mirrors revm's `MainnetHandler`
-/// with only `reward_beneficiary` overridden to a no-op, and replaces the old `Galxe/revm` fork's
-/// `cfg.lazy_reward` flag so grevm can build against upstream revm.
-struct NoRewardHandler<EVM, ERROR, FRAME> {
-    _phantom: core::marker::PhantomData<(EVM, ERROR, FRAME)>,
-}
-
-impl<EVM, ERROR, FRAME> Default for NoRewardHandler<EVM, ERROR, FRAME> {
-    fn default() -> Self {
-        Self { _phantom: core::marker::PhantomData }
-    }
-}
-
-impl<EVM, ERROR, FRAME> Handler for NoRewardHandler<EVM, ERROR, FRAME>
-where
-    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState>>, Frame = FRAME>,
-    ERROR: EvmTrError<EVM>,
-    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
-{
-    type Evm = EVM;
-    type Error = ERROR;
-    type HaltReason = HaltReason;
-
-    /// Skip the miner reward; grevm applies it lazily at commit time.
-    fn reward_beneficiary(
-        &self,
-        _evm: &mut Self::Evm,
-        _exec_result: &mut FrameResult,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-}
-
-#[derive(Metrics)]
-#[metrics(scope = "grevm")]
-struct ExecuteMetrics {
-    /// Total number of transactions
-    total_tx_cnt: metrics::Histogram,
-    /// Number of conflict incarnations
-    conflict_cnt: metrics::Histogram,
-    /// Number of validation incarnations
-    validation_cnt: metrics::Histogram,
-    /// Number of execution incarnations
-    execution_cnt: metrics::Histogram,
-    /// Number of validation reset
-    reset_validation_idx_cnt: metrics::Histogram,
-    /// Number of useless dependency update
-    useless_dependent_update: metrics::Histogram,
-
-    /// Number of conflict by miner&self-destruct
-    conflict_by_miner: metrics::Histogram,
-    /// Number of conflict by evm error
-    conflict_by_error: metrics::Histogram,
-    /// Number of conflict by estimate
-    conflict_by_estimate: metrics::Histogram,
-    /// Number of conflict by version
-    conflict_by_version: metrics::Histogram,
-    /// Number of transactions whose incarnation == 1
-    one_attempt_with_dependency: metrics::Histogram,
-    /// Number of transactions whose incarnation > 2
-    more_attempts_with_dependency: metrics::Histogram,
-    /// Number of transactions without dependency
-    no_dependency_txs: metrics::Histogram,
-    /// Number of conflict transactions
-    conflict_txs: metrics::Histogram,
-    /// Executition time(nanosecond)
-    execution_time: metrics::Histogram,
-    /// Commit time(nanosecond)
-    commit_time: metrics::Histogram,
-    /// Total time(nanosecond)
-    total_time: metrics::Histogram,
-}
-
-#[derive(Default)]
-struct ExecuteMetricsCollector {
-    total_tx_cnt: AtomicUsize,
-    conflict_cnt: AtomicUsize,
-    validation_cnt: AtomicUsize,
-    execution_cnt: AtomicUsize,
-    reset_validation_idx_cnt: AtomicUsize,
-    useless_dependent_update: AtomicUsize,
-
-    conflict_by_miner: AtomicUsize,
-    conflict_by_error: AtomicUsize,
-    conflict_by_estimate: AtomicUsize,
-    conflict_by_version: AtomicUsize,
-    one_attempt_with_dependency: AtomicUsize,
-    more_attempts_with_dependency: AtomicUsize,
-    no_dependency_txs: AtomicUsize,
-    conflict_txs: AtomicUsize,
-    execution_time: AtomicUsize,
-    commit_time: AtomicUsize,
-    total_time: AtomicUsize,
-}
-
-impl ExecuteMetricsCollector {
-    fn report(&self) {
-        let execute_metrics = ExecuteMetrics::default();
-        execute_metrics.total_tx_cnt.record(self.total_tx_cnt.load(Ordering::Relaxed) as f64);
-        execute_metrics.conflict_cnt.record(self.conflict_cnt.load(Ordering::Relaxed) as f64);
-        execute_metrics.validation_cnt.record(self.validation_cnt.load(Ordering::Relaxed) as f64);
-        execute_metrics.execution_cnt.record(self.execution_cnt.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .reset_validation_idx_cnt
-            .record(self.reset_validation_idx_cnt.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .useless_dependent_update
-            .record(self.useless_dependent_update.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .conflict_by_miner
-            .record(self.conflict_by_miner.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .conflict_by_error
-            .record(self.conflict_by_error.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .conflict_by_estimate
-            .record(self.conflict_by_estimate.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .conflict_by_version
-            .record(self.conflict_by_version.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .one_attempt_with_dependency
-            .record(self.one_attempt_with_dependency.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .more_attempts_with_dependency
-            .record(self.more_attempts_with_dependency.load(Ordering::Relaxed) as f64);
-        execute_metrics
-            .no_dependency_txs
-            .record(self.no_dependency_txs.load(Ordering::Relaxed) as f64);
-        execute_metrics.conflict_txs.record(self.conflict_txs.load(Ordering::Relaxed) as f64);
-        let execution_time = self.execution_time.load(Ordering::Relaxed);
-        if execution_time > 0 {
-            execute_metrics.execution_time.record(execution_time as f64);
-        }
-        execute_metrics.commit_time.record(self.commit_time.load(Ordering::Relaxed) as f64);
-        execute_metrics.total_time.record(self.total_time.load(Ordering::Relaxed) as f64);
-    }
-}
-
-/// The `SchedulerContext` provides the execution context for transaction scheduling. The
-/// `validation_idx` parameter serves as the validation cursor, mirroring its functionality in
-/// Block-STM. Unlike Block-STM, Grevm eliminates the execution cursor and instead employs
-/// `TxDependency` to drive transaction execution. Since transaction execution order is determined
-/// by the DAG rather than sequential numbering, Grevm utilizes the `ContinuousDetectSet` to monitor
-/// consecutively executed transactions. Compared to Block-STM where `validation_idx` can be
-/// reached when executing, this approach enables validation right aflter execution while
-/// significantly reducing the number of validation tasks through the ContinuousDetectSet mechanism.
-struct SchedulerContext {
-    num_txs: usize,
-    validation_idx: AtomicUsize,
-    finality_idx: AtomicUsize,
-    commit_idx: AtomicUsize,
-    executed_set: ContinuousDetectSet,
-    reset_validation_idx_cnt: AtomicUsize,
-
-    // To implement asynchronous transaction commitment (`StateAsyncCommit`), Grevm must handle
-    // complex scenarios like: tx2/tx4 being unconfirmed while tx3 enters conflict state and
-    // requires re-execution (rolling back to `validation_idx`=3). Under high concurrency, if tx3
-    // re-enters unconfirmed state before tx4 begins validation, tx4 might get incorrectly
-    // committed. While locking would be the naive solution, extensive optimization attempts
-    // revealed that even minimal critical sections cause unacceptable
-    // performance degradation(reference: https://github.com/Galxe/grevm/issues/64).
-    // Grevm instead employs logical timestamps to verify transaction availability in unconfirmed
-    // states, maintaining lock-free execution while ensuring correctness.
-    logical_ts: AtomicUsize,
-    lower_ts: Vec<AtomicUsize>,
-    unconfirmed_ts: Vec<AtomicUsize>,
-}
-
-impl SchedulerContext {
-    fn new(num_txs: usize) -> Self {
-        Self {
-            num_txs,
-            validation_idx: AtomicUsize::new(0),
-            finality_idx: AtomicUsize::new(0),
-            commit_idx: AtomicUsize::new(0),
-            executed_set: ContinuousDetectSet::new(num_txs),
-            reset_validation_idx_cnt: AtomicUsize::new(0),
-            logical_ts: AtomicUsize::new(1),
-            lower_ts: (0..num_txs).map(|_| AtomicUsize::new(0)).collect(),
-            unconfirmed_ts: (0..num_txs).map(|_| AtomicUsize::new(0)).collect(),
-        }
-    }
-
-    fn reset_validation_idx(&self, index: usize) {
-        if index < self.num_txs {
-            let ts = self.logical_ts.fetch_add(1, Ordering::AcqRel);
-            // Rolling back the `validation_idx` implies that the commitment time of subsequent
-            // transactions must be logically later than the current timestamp.
-            self.lower_ts[index].fetch_max(ts, Ordering::AcqRel);
-            let prev = self.validation_idx.fetch_min(index, Ordering::AcqRel);
-            if prev > index {
-                self.reset_validation_idx_cnt.fetch_add(1, Ordering::AcqRel);
-            }
-        }
-    }
-
-    fn logical_timestamp(&self) -> usize {
-        self.logical_ts.fetch_add(1, Ordering::AcqRel)
-    }
-
-    fn executed(&self, index: usize) {
-        self.executed_set.add(index);
-    }
-
-    fn unconfirmed(&self, index: usize, ts: usize) {
-        self.unconfirmed_ts[index].fetch_max(ts, Ordering::AcqRel);
-    }
-
-    fn finished(&self) -> bool {
-        self.finality_idx.load(Ordering::Acquire) >= self.num_txs
-    }
-
-    fn finality_idx(&self) -> usize {
-        self.finality_idx.load(Ordering::Acquire)
-    }
-
-    fn validation_idx(&self) -> usize {
-        self.validation_idx.load(Ordering::Acquire)
-    }
-
-    fn should_schedule(&self, executing_idx: usize) -> bool {
-        let validation_idx = self.validation_idx.load(Ordering::Acquire);
-        let should_validation =
-            validation_idx < executing_idx && validation_idx < self.executed_set.continuous_idx();
-        let should_execution = executing_idx < self.num_txs;
-        should_validation || should_execution
-    }
-
-    fn next_validation_idx(&self, executing_idx: usize) -> Option<usize> {
-        let validation_idx = self.validation_idx.load(Ordering::Acquire);
-        if validation_idx < executing_idx && validation_idx < self.executed_set.continuous_idx() {
-            let validation_idx = self.validation_idx.fetch_add(1, Ordering::AcqRel);
-            if validation_idx < self.num_txs {
-                return Some(validation_idx);
-            }
-        }
-        None
-    }
-}
 
 /// The `Scheduler` struct is responsible for managing the parallel execution of transactions
 /// in a block. It coordinates the execution, validation, and finalization of transactions
@@ -330,6 +61,8 @@ where
     mv_memory: MVMemory,
     scheduler_ctx: SchedulerContext,
     custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>,
+    config: GrevmConfig,
+    reserve_planner: Option<Arc<ReservePlanner>>,
 
     abort: AtomicBool,
     abort_reason: OnceLock<AbortReason<DB::Error>>,
@@ -370,12 +103,74 @@ where
         with_hints: bool,
         custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
     ) -> Self {
+        Self::new_with_config(
+            cfg,
+            env,
+            txs,
+            state,
+            with_hints,
+            custom_precompiles,
+            GrevmConfig::from_env(),
+        )
+    }
+
+    /// Create a scheduler with an explicit, block-scoped runtime configuration.
+    pub fn new_with_config(
+        cfg: CfgEnv,
+        env: BlockEnv,
+        txs: Arc<Vec<TxEnv>>,
+        state: ParallelState<DB>,
+        with_hints: bool,
+        custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
+        config: GrevmConfig,
+    ) -> Self {
+        assert!(config.concurrency_level > 0, "grevm concurrency level must be greater than zero");
+        Self::build(cfg, env, txs, state, with_hints, custom_precompiles, config)
+    }
+
+    /// Compatibility constructor for callers that only override delegated-account safety.
+    #[deprecated(note = "use Scheduler::new_with_config and GrevmConfig")]
+    pub fn new_with_delegated_safety(
+        cfg: CfgEnv,
+        env: BlockEnv,
+        txs: Arc<Vec<TxEnv>>,
+        state: ParallelState<DB>,
+        with_hints: bool,
+        custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
+        delegated_safety: DelegatedSafetyConfig,
+    ) -> Self {
+        Self::new_with_config(
+            cfg,
+            env,
+            txs,
+            state,
+            with_hints,
+            custom_precompiles,
+            GrevmConfig::from_env().with_delegated_safety(delegated_safety),
+        )
+    }
+
+    fn build(
+        cfg: CfgEnv,
+        env: BlockEnv,
+        txs: Arc<Vec<TxEnv>>,
+        state: ParallelState<DB>,
+        with_hints: bool,
+        custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
+        config: GrevmConfig,
+    ) -> Self {
         let num_txs = txs.len();
         let tx_dependency = if with_hints {
             ParallelExecutionHints::new(txs.clone()).parse_hints()
         } else {
             TxDependency::new(num_txs)
         };
+        // Construction is O(1): sender indexing and per-account maximum-cost suffixes remain lazy
+        // until surviving delegated execution actually debits an account.
+        let reserve_planner = config
+            .delegated_safety
+            .reserve_delegated_balance
+            .then(|| Arc::new(ReservePlanner::new(txs.clone())));
         Self {
             cfg,
             env,
@@ -389,6 +184,8 @@ where
             mv_memory: MVMemory::new(),
             scheduler_ctx: SchedulerContext::new(num_txs),
             custom_precompiles: custom_precompiles.unwrap_or_else(|| Arc::new(Vec::new())),
+            config,
+            reserve_planner,
             abort: AtomicBool::new(false),
             abort_reason: OnceLock::new(),
             metrics: ExecuteMetricsCollector::default(),
@@ -510,18 +307,24 @@ where
         (self.results.into_inner(), self.state.into_inner())
     }
 
-    /// Paralle execution
+    /// Execute using the scheduler's unified runtime configuration.
+    pub fn execute(&self) -> Result<(), GrevmError<DB::Error>> {
+        self.parallel_execute(None)
+    }
+
+    /// Execute with an optional per-call concurrency override.
+    ///
+    /// New integrations should configure [`GrevmConfig::concurrency_level`] and call
+    /// [`Self::execute`].
     pub fn parallel_execute(
         &self,
         concurrency_level: Option<usize>,
     ) -> Result<(), GrevmError<DB::Error>> {
         let start_time = Instant::now();
         self.metrics.total_tx_cnt.store(self.block_size, Ordering::Relaxed);
-        let concurrency_level = concurrency_level.unwrap_or(
-            std::env::var("GREVM_CONCURRENT_LEVEL")
-                .map_or(*CONCURRENT_LEVEL, |s| s.parse().unwrap_or(*CONCURRENT_LEVEL)),
-        );
-        if *FALLBACK_SEQUENTIAL || self.block_size < *MIN_PARALLEL_TXS {
+        let concurrency_level = concurrency_level.unwrap_or(self.config.concurrency_level);
+        assert!(concurrency_level > 0, "grevm concurrency level must be greater than zero");
+        if self.config.force_sequential || self.block_size < self.config.min_parallel_txs {
             return self.fallback_sequential();
         }
         let commiter = Mutex::new(StateAsyncCommit::new(
@@ -558,33 +361,15 @@ where
                     // the nonce against committed state; a mismatch leaves the transaction
                     // uncommitted and triggers sequential revalidation from that transaction.
                     cfg.disable_nonce_check = true;
-                    // Build the raw revm EVM (not wrapped in `EthEvm`) so we can drive a custom
-                    // `Handler` that skips the miner reward — the reward is deferred and applied at
-                    // commit time (see `async_commit`).
-                    let mut evm = Context::mainnet()
-                        .with_db(cache_db)
-                        .with_cfg(cfg)
-                        .with_block(self.env.clone())
-                        .build_mainnet_with_inspector(NoOpInspector {})
-                        .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                            PrecompileSpecId::from_spec_id(self.cfg.spec),
-                        )));
-                    // Apply additional precompiles if provided
-                    for (address, precompile) in self.custom_precompiles.iter() {
-                        let precompile_clone = precompile.clone();
-                        evm.precompiles.apply_precompile(&address, move |_| Some(precompile_clone));
-                    }
-
-                    let mut task = self.next();
-                    while let Some(current_task) = task {
-                        task = match current_task {
-                            Task::Execution(tx_version) => self.execute(&mut evm, tx_version),
-                            Task::Validation(tx_version) => self.validate(tx_version),
-                        };
-                        if task.is_none() && !self.abort.load(Ordering::Acquire) {
-                            task = self.next();
-                        }
-                    }
+                    let mut executor = GrevmExecutor::new(
+                        cache_db,
+                        cfg,
+                        self.env.clone(),
+                        self.custom_precompiles.as_ref(),
+                        self.config.delegated_safety,
+                        self.reserve_planner.clone(),
+                    );
+                    self.run_worker(&mut executor);
                 });
             }
         });
@@ -659,96 +444,6 @@ where
         Ok(())
     }
 
-    fn fallback_after_parallel_error(
-        &self,
-        txid: TxId,
-        message: &str,
-    ) -> Result<(), GrevmError<DB::Error>> {
-        tracing::error!(
-            target: "grevm::scheduler",
-            block_number = %self.env.number,
-            txid,
-            reason = message,
-            "parallel execution invariant failed; falling back to sequential execution",
-        );
-        self.fallback_sequential()
-    }
-
-    /// Fallback to sequential execution
-    pub fn fallback_sequential(&self) -> Result<(), GrevmError<DB::Error>> {
-        let mut results = self.results.lock();
-        let num_commit = results.len();
-        if num_commit == self.block_size {
-            return Ok(());
-        }
-
-        let mut sequential_results = Vec::with_capacity(self.block_size - num_commit);
-        let mut commit_guard = CommitGuard::new(&self.state);
-        let state_mut = commit_guard.state_mut();
-        {
-            let evm = Context::mainnet()
-                .with_db(state_mut)
-                .with_cfg(self.cfg.clone())
-                .with_block(self.env.clone())
-                .build_mainnet_with_inspector(NoOpInspector {})
-                .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                    PrecompileSpecId::from_spec_id(self.cfg.spec),
-                )));
-            let mut evm = EthEvm::new(evm, false);
-            // Apply additional precompiles if provided
-            for (address, precompile) in self.custom_precompiles.iter() {
-                let precompile_clone = precompile.clone();
-                evm.precompiles_mut().apply_precompile(&address, move |_| Some(precompile_clone));
-            }
-            for txid in num_commit..self.block_size {
-                let tx = &self.txs[txid];
-                if !self.cfg.disable_nonce_check && tx.nonce == u64::MAX {
-                    let state_nonce = match evm.db_mut().basic_ref(tx.caller) {
-                        Ok(info) => info.map_or(0, |info| info.nonce),
-                        Err(error) => {
-                            return Err(GrevmError { txid, error: EVMError::Database(error) });
-                        }
-                    };
-                    if state_nonce == u64::MAX {
-                        let error = crate::InvalidTransaction::NonceOverflowInTransaction;
-                        tracing::warn!(
-                            target: "grevm::scheduler",
-                            block_number = %self.env.number,
-                            txid,
-                            ?error,
-                            "skipping invalid transaction during sequential fallback",
-                        );
-                        sequential_results.push(TxExecutionOutcome::Skipped(error));
-                        self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
-                }
-                let result_and_state = match evm.transact_raw(self.txs[txid].clone()) {
-                    Ok(result_and_state) => result_and_state,
-                    Err(EVMError::Transaction(error)) => {
-                        tracing::warn!(
-                            target: "grevm::scheduler",
-                            block_number = %self.env.number,
-                            txid,
-                            ?error,
-                            "skipping invalid transaction during sequential fallback",
-                        );
-                        sequential_results.push(TxExecutionOutcome::Skipped(error));
-                        self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
-                    Err(error) => return Err(GrevmError { txid, error }),
-                };
-
-                evm.db_mut().commit(result_and_state.state);
-                sequential_results.push(TxExecutionOutcome::Executed(result_and_state.result));
-                self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-        results.extend(sequential_results);
-        Ok(())
-    }
-
     fn abort(&self, abort_reason: AbortReason<DB::Error>) {
         self.abort_reason.get_or_init(|| abort_reason);
         self.abort.store(true, Ordering::Release);
@@ -760,8 +455,31 @@ where
     /// - ​Unconfirmed Miner/Self-Destruct Accounts: The transaction interacts with miner rewards or
     ///   self-destructed accounts before their committing transaction is finalized (txid ≠
     ///   commit_idx)
-    fn execute(&self, evm: &mut GrevmEvm<'_, DB>, tx_version: TxVersion) -> Option<Task> {
-        let TxVersion { txid, incarnation } = tx_version;
+    fn run_worker<'db>(&self, executor: &mut impl ParallelTransactionExecutor<'db, DB>)
+    where
+        DB: 'db,
+    {
+        let mut task = self.next();
+        while let Some(current_task) = task {
+            task = match current_task {
+                Task::Execution(version) => self.execute_task(executor, version),
+                Task::Validation(version) => self.validate(version),
+            };
+            if task.is_none() && !self.abort.load(Ordering::Acquire) {
+                task = self.next();
+            }
+        }
+    }
+
+    fn execute_task<'db>(
+        &self,
+        executor: &mut impl ParallelTransactionExecutor<'db, DB>,
+        tx_version: TxVersion,
+    ) -> Option<Task>
+    where
+        DB: 'db,
+    {
+        let TxVersion { txid, incarnation } = tx_version.clone();
         let mut tx_state = self.tx_states[txid].lock();
         if tx_state.status != TransactionStatus::Executing {
             return None;
@@ -775,21 +493,9 @@ where
         }
         self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
 
-        evm.db_mut().reset_state(TxVersion::new(txid, incarnation));
         let tx_env = self.txs[txid].clone();
         let commit_idx = self.scheduler_ctx.commit_idx.load(Ordering::Acquire);
-        // Execute with the miner reward suppressed (see `NoRewardHandler`); the reward is applied
-        // later in `async_commit`. This replicates revm's `ExecuteEvm::transact` (set tx → run
-        // handler → finalize) but with our handler instead of the default `MainnetHandler`.
-        //
-        // `finalize` clears the journal and MUST run even when execution errors: this EVM is reused
-        // for the next transaction on the same thread, so a dirty journal left by a failed
-        // (optimistic) tx would corrupt the following one. revm's `transact` finalizes
-        // unconditionally and only then propagates the error — we do the same.
-        evm.ctx.set_tx(tx_env);
-        let output_or_error = NoRewardHandler::default().run(evm);
-        let state = evm.finalize();
-        let result = output_or_error.map(|result| ResultAndState { result, state });
+        let result = executor.transact(tx_version, tx_env);
 
         // The `​write_new_locations` mechanism optimizes validation by intelligently reducing
         // redundant verification tasks. Under standard validation logic, when a conflicted
@@ -805,12 +511,13 @@ where
             Ok(result_and_state) => {
                 // only the miner involved in transaction should accumulate the rewards of finality
                 // txs return true if the tx doesn't visit the miner account
-                let read_accurate_origin = evm.db_mut().read_accurate_origin();
+                let read_accurate_origin = executor.db_mut().read_accurate_origin();
 
-                let blocking_txs = evm.db_mut().take_estimate_txs();
+                let blocking_txs = executor.db_mut().take_estimate_txs();
                 conflict = !read_accurate_origin || !blocking_txs.is_empty();
-                let read_set = evm.db_mut().take_read_set();
-                let write_set = evm.db_mut().update_mv_memory(&result_and_state.state, conflict);
+                let read_set = executor.db_mut().take_read_set();
+                let write_set =
+                    executor.db_mut().update_mv_memory(&result_and_state.state, conflict);
 
                 let mut last_result = self.tx_results[txid].lock();
                 if let Some(last_result) = last_result.as_ref() {
@@ -821,11 +528,10 @@ where
                         }
                     }
                     for location in &last_result.write_set {
-                        if !write_set.contains(location) {
-                            if let Some(mut written_transactions) = self.mv_memory.get_mut(location)
-                            {
-                                written_transactions.remove(&txid);
-                            }
+                        if !write_set.contains(location) &&
+                            let Some(mut written_transactions) = self.mv_memory.get_mut(location)
+                        {
+                            written_transactions.remove(&txid);
                         }
                     }
                 } else {
@@ -996,9 +702,7 @@ where
 
         if conflict {
             // update dependency
-            let dep_tx = dependency.and_then(|dep| {
-                if dep >= self.scheduler_ctx.finality_idx() { Some(dep) } else { None }
-            });
+            let dep_tx = dependency.filter(|&dep| dep >= self.scheduler_ctx.finality_idx());
             self.tx_dependency.add(txid, dep_tx);
         }
         None
@@ -1006,10 +710,10 @@ where
 
     fn mark_estimate(&self, txid: TxId, write_set: &HashSet<LocationAndType>) {
         for location in write_set {
-            if let Some(mut written_transactions) = self.mv_memory.get_mut(location) {
-                if let Some(entry) = written_transactions.get_mut(&txid) {
-                    entry.estimate = true;
-                }
+            if let Some(mut written_transactions) = self.mv_memory.get_mut(location) &&
+                let Some(entry) = written_transactions.get_mut(&txid)
+            {
+                entry.estimate = true;
             }
         }
     }
@@ -1021,18 +725,15 @@ where
     ) -> Option<TxId> {
         let mut max_dep_id = None;
         for location in read_set.keys() {
-            if let Some(written_transactions) = self.mv_memory.get(location) {
-                // To prevent dependency explosion, only add the tx with the highest TxId in
-                // written_transactions
-                if let Some((&dep_id, _)) = written_transactions.range(..txid).next_back() {
-                    if (max_dep_id.is_none() || dep_id > max_dep_id.unwrap()) &&
-                        dep_id >= self.scheduler_ctx.finality_idx()
-                    {
-                        max_dep_id = Some(dep_id);
-                        if dep_id == txid - 1 {
-                            return max_dep_id;
-                        }
-                    }
+            if let Some(written_transactions) = self.mv_memory.get(location) &&
+                let Some((&dep_id, _)) = written_transactions.range(..txid).next_back() &&
+                max_dep_id.is_none_or(|current| dep_id > current) &&
+                dep_id >= self.scheduler_ctx.finality_idx()
+            {
+                // To prevent dependency explosion, keep only the highest preceding transaction.
+                max_dep_id = Some(dep_id);
+                if dep_id == txid - 1 {
+                    return max_dep_id;
                 }
             }
         }
@@ -1074,108 +775,12 @@ where
                 }
             }
 
-            if let Some(execute_id) = self.tx_dependency.next() {
-                if let Some(task) = self.execution_task(execute_id) {
-                    return Some(task);
-                }
+            if let Some(execute_id) = self.tx_dependency.next() &&
+                let Some(task) = self.execution_task(execute_id)
+            {
+                return Some(task);
             }
         }
         None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use revm_database::EmptyDB;
-    use revm_primitives::{TxKind, U256, hardfork::SpecId};
-    use revm_state::AccountInfo;
-
-    fn empty_scheduler(num_txs: usize) -> Scheduler<EmptyDB> {
-        Scheduler::new(
-            CfgEnv::new_with_spec(SpecId::SHANGHAI),
-            BlockEnv::default(),
-            Arc::new(vec![TxEnv::default(); num_txs]),
-            ParallelState::new(EmptyDB::default(), true, false),
-            false,
-            None,
-        )
-    }
-
-    #[test]
-    fn fatal_execution_abort_uses_recorded_txid_not_finality_idx() {
-        let scheduler = empty_scheduler(3);
-        *scheduler.tx_results[2].lock() = Some(TransactionResult {
-            read_set: Default::default(),
-            write_set: Default::default(),
-            execute_result: Err(EVMError::Custom("fatal execution error".to_owned())),
-        });
-        scheduler.abort(AbortReason::FatalEvmError(2));
-
-        let error = scheduler.post_execute().expect_err("fatal abort must be returned");
-        assert_eq!(scheduler.scheduler_ctx.finality_idx(), 0);
-        assert_eq!(error.txid, 2);
-        assert!(matches!(
-            error.error,
-            EVMError::Custom(message) if message == "fatal execution error"
-        ));
-    }
-
-    #[test]
-    fn commit_abort_carries_error_without_using_tx_results() {
-        let scheduler = empty_scheduler(3);
-        scheduler.abort(AbortReason::CommitError(GrevmError {
-            txid: 1,
-            error: EVMError::Custom("commit error".to_owned()),
-        }));
-
-        let error = scheduler.post_execute().expect_err("commit abort must be returned");
-        assert_eq!(error.txid, 1);
-        assert!(matches!(
-            error.error,
-            EVMError::Custom(message) if message == "commit error"
-        ));
-        assert!(scheduler.tx_results.iter().all(|result| result.lock().is_none()));
-    }
-
-    #[test]
-    fn parallel_error_replays_suffix_from_committed_prefix() {
-        let caller = Address::from([0xCA; 20]);
-        let receiver = Address::from([0xCB; 20]);
-        let state = ParallelState::new(EmptyDB::default(), true, false);
-        state.insert_account(
-            caller,
-            AccountInfo { balance: U256::from(1_000_000), nonce: 1, ..Default::default() },
-        );
-        let suffix_tx = TxEnv {
-            caller,
-            gas_limit: 21_000,
-            kind: TxKind::Call(receiver),
-            value: U256::from(1),
-            nonce: 1,
-            ..Default::default()
-        };
-        let scheduler = Scheduler::new(
-            CfgEnv::new_with_spec(SpecId::SHANGHAI),
-            BlockEnv::default(),
-            Arc::new(vec![TxEnv::default(), suffix_tx]),
-            state,
-            false,
-            None,
-        );
-        // Model one already committed transaction. Fallback must preserve this prefix and start
-        // from tx 1 against its committed post-state.
-        scheduler.results.lock().push(TxExecutionOutcome::Skipped(
-            crate::InvalidTransaction::NonceTooLow { tx: 0, state: 1 },
-        ));
-        scheduler.abort(AbortReason::ParallelError {
-            txid: 1,
-            message: "test parallel invariant failure",
-        });
-
-        scheduler.post_execute().expect("sequential suffix replay must succeed");
-        let results = scheduler.results.lock();
-        assert_eq!(results.len(), 2);
-        assert!(matches!(results[1], TxExecutionOutcome::Executed(_)));
     }
 }

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -1,0 +1,83 @@
+use crate::utils::ContinuousDetectSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Lock-free cursors and logical timestamps used by the scheduling state machine.
+pub(super) struct SchedulerContext {
+    num_txs: usize,
+    validation_idx: AtomicUsize,
+    pub(super) finality_idx: AtomicUsize,
+    pub(super) commit_idx: AtomicUsize,
+    pub(super) executed_set: ContinuousDetectSet,
+    pub(super) reset_validation_idx_cnt: AtomicUsize,
+    logical_ts: AtomicUsize,
+    pub(super) lower_ts: Vec<AtomicUsize>,
+    pub(super) unconfirmed_ts: Vec<AtomicUsize>,
+}
+
+impl SchedulerContext {
+    pub(super) fn new(num_txs: usize) -> Self {
+        Self {
+            num_txs,
+            validation_idx: AtomicUsize::new(0),
+            finality_idx: AtomicUsize::new(0),
+            commit_idx: AtomicUsize::new(0),
+            executed_set: ContinuousDetectSet::new(num_txs),
+            reset_validation_idx_cnt: AtomicUsize::new(0),
+            logical_ts: AtomicUsize::new(1),
+            lower_ts: (0..num_txs).map(|_| AtomicUsize::new(0)).collect(),
+            unconfirmed_ts: (0..num_txs).map(|_| AtomicUsize::new(0)).collect(),
+        }
+    }
+
+    pub(super) fn reset_validation_idx(&self, index: usize) {
+        if index >= self.num_txs {
+            return;
+        }
+        let timestamp = self.logical_ts.fetch_add(1, Ordering::AcqRel);
+        self.lower_ts[index].fetch_max(timestamp, Ordering::AcqRel);
+        let previous = self.validation_idx.fetch_min(index, Ordering::AcqRel);
+        if previous > index {
+            self.reset_validation_idx_cnt.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    pub(super) fn logical_timestamp(&self) -> usize {
+        self.logical_ts.fetch_add(1, Ordering::AcqRel)
+    }
+
+    pub(super) fn executed(&self, index: usize) {
+        self.executed_set.add(index);
+    }
+
+    pub(super) fn unconfirmed(&self, index: usize, timestamp: usize) {
+        self.unconfirmed_ts[index].fetch_max(timestamp, Ordering::AcqRel);
+    }
+
+    pub(super) fn finished(&self) -> bool {
+        self.finality_idx.load(Ordering::Acquire) >= self.num_txs
+    }
+
+    pub(super) fn finality_idx(&self) -> usize {
+        self.finality_idx.load(Ordering::Acquire)
+    }
+
+    pub(super) fn validation_idx(&self) -> usize {
+        self.validation_idx.load(Ordering::Acquire)
+    }
+
+    pub(super) fn should_schedule(&self, executing_idx: usize) -> bool {
+        let validation_idx = self.validation_idx.load(Ordering::Acquire);
+        let should_validate =
+            validation_idx < executing_idx && validation_idx < self.executed_set.continuous_idx();
+        should_validate || executing_idx < self.num_txs
+    }
+
+    pub(super) fn next_validation_idx(&self, executing_idx: usize) -> Option<usize> {
+        let validation_idx = self.validation_idx.load(Ordering::Acquire);
+        if validation_idx >= executing_idx || validation_idx >= self.executed_set.continuous_idx() {
+            return None;
+        }
+        let next = self.validation_idx.fetch_add(1, Ordering::AcqRel);
+        (next < self.num_txs).then_some(next)
+    }
+}

--- a/src/scheduler/executor.rs
+++ b/src/scheduler/executor.rs
@@ -1,0 +1,137 @@
+//! EVM construction and transaction driving for the scheduler.
+
+use crate::{
+    ParallelState, TxVersion,
+    cache_db::CacheDB,
+    delegated_safety::{
+        BeneficiaryMode, DelegatedSafetyConfig, GrevmHandler, ReserveMode, ReservePlanner,
+        gravity_instructions,
+    },
+};
+use alloy_evm::{
+    Database as AlloyDatabase,
+    precompiles::{DynPrecompile, PrecompilesMap},
+};
+use revm::{
+    Context, DatabaseRef, ExecuteEvm, MainBuilder, MainContext,
+    context::Evm as RevmEvm,
+    handler::{EthFrame, instructions::EthInstructions},
+    interpreter::interpreter::EthInterpreter,
+    precompile::{PrecompileSpecId, Precompiles},
+};
+use revm_context::{
+    BlockEnv, CfgEnv, ContextSetters, ContextTr, TxEnv,
+    result::{EVMError, ExecutionResult, ResultAndState},
+};
+use revm_inspector::NoOpInspector;
+use revm_primitives::Address;
+use std::sync::Arc;
+
+type GrevmContext<DB> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
+
+pub(crate) type GrevmEvm<DB> = RevmEvm<
+    GrevmContext<DB>,
+    NoOpInspector,
+    EthInstructions<EthInterpreter, GrevmContext<DB>>,
+    PrecompilesMap,
+    EthFrame,
+>;
+
+/// The only EVM operations needed by the parallel scheduling state machine.
+pub(crate) trait ParallelTransactionExecutor<'db, DB>
+where
+    DB: DatabaseRef,
+{
+    fn transact(
+        &mut self,
+        version: TxVersion,
+        tx: TxEnv,
+    ) -> Result<ResultAndState, EVMError<DB::Error>>;
+
+    fn db_mut(&mut self) -> &mut CacheDB<'db, ParallelState<DB>>;
+}
+
+/// One executor for all four delegated-safety configurations.
+///
+/// CREATE protection is selected once in the instruction table. Reserve protection is an optional
+/// handler around the same upstream journal and precompile provider.
+pub(crate) struct GrevmExecutor<'a, DB>
+where
+    DB: DatabaseRef,
+{
+    evm: GrevmEvm<CacheDB<'a, ParallelState<DB>>>,
+    /// `Some` enables delegated-balance reserve checks; `None` adds no checkpoint or scan.
+    reserve_planner: Option<Arc<ReservePlanner>>,
+}
+
+impl<'a, DB> GrevmExecutor<'a, DB>
+where
+    DB: DatabaseRef,
+    DB::Error: Send + Sync + 'static,
+{
+    pub(crate) fn new(
+        db: CacheDB<'a, ParallelState<DB>>,
+        cfg: CfgEnv,
+        block: BlockEnv,
+        custom_precompiles: &[(Address, DynPrecompile)],
+        safety: DelegatedSafetyConfig,
+        reserve_planner: Option<Arc<ReservePlanner>>,
+    ) -> Self {
+        let evm = build_evm(db, cfg, block, custom_precompiles, safety.forbid_delegated_create);
+        debug_assert_eq!(safety.reserve_delegated_balance, reserve_planner.is_some());
+        Self { evm, reserve_planner }
+    }
+}
+
+impl<'a, DB> ParallelTransactionExecutor<'a, DB> for GrevmExecutor<'a, DB>
+where
+    DB: DatabaseRef,
+    DB::Error: Send + Sync + 'static,
+{
+    fn transact(
+        &mut self,
+        version: TxVersion,
+        tx: TxEnv,
+    ) -> Result<ResultAndState, EVMError<DB::Error>> {
+        self.evm.db_mut().reset_state(version.clone());
+        self.evm.ctx.set_tx(tx);
+        let reserve_mode = ReserveMode::from_planner(version.txid, self.reserve_planner.as_deref());
+        let output: Result<ExecutionResult, EVMError<DB::Error>> =
+            GrevmHandler::new(reserve_mode, BeneficiaryMode::Deferred).run(&mut self.evm);
+        let state = self.evm.finalize();
+        output.map(|result| ResultAndState { result, state })
+    }
+
+    fn db_mut(&mut self) -> &mut CacheDB<'a, ParallelState<DB>> {
+        self.evm.db_mut()
+    }
+}
+
+pub(crate) fn build_evm<DB>(
+    db: DB,
+    cfg: CfgEnv,
+    block: BlockEnv,
+    custom_precompiles: &[(Address, DynPrecompile)],
+    forbid_delegated_create: bool,
+) -> GrevmEvm<DB>
+where
+    DB: AlloyDatabase,
+{
+    let spec = cfg.spec;
+    let mut evm = Context::mainnet()
+        .with_db(db)
+        .with_cfg(cfg)
+        .with_block(block)
+        .build_mainnet_with_inspector(NoOpInspector {})
+        .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
+            PrecompileSpecId::from_spec_id(spec),
+        )));
+    if forbid_delegated_create {
+        evm.instruction = gravity_instructions();
+    }
+    for (address, precompile) in custom_precompiles {
+        let precompile = precompile.clone();
+        evm.precompiles.apply_precompile(address, move |_| Some(precompile));
+    }
+    evm
+}

--- a/src/scheduler/fallback.rs
+++ b/src/scheduler/fallback.rs
@@ -1,0 +1,109 @@
+//! Sequential suffix replay used for configured and recovery fallbacks.
+
+use super::{Scheduler, executor::build_evm};
+use crate::{
+    GrevmError, InvalidTransaction, TxExecutionOutcome, TxId,
+    async_commit::CommitGuard,
+    delegated_safety::{BeneficiaryMode, GrevmHandler, ReserveMode},
+};
+use revm::{DatabaseCommit, DatabaseRef, ExecuteEvm};
+use revm_context::{
+    ContextSetters, ContextTr, TxEnv,
+    result::{EVMError, ExecutionResult},
+};
+use std::sync::atomic::Ordering;
+
+impl<DB> Scheduler<DB>
+where
+    DB: DatabaseRef + Send + Sync,
+    DB::Error: Clone + Send + Sync + 'static,
+{
+    pub(super) fn fallback_after_parallel_error(
+        &self,
+        txid: TxId,
+        message: &str,
+    ) -> Result<(), GrevmError<DB::Error>> {
+        tracing::error!(
+            target: "grevm::scheduler",
+            block_number = %self.env.number,
+            txid,
+            reason = message,
+            "parallel execution invariant failed; falling back to sequential execution",
+        );
+        self.fallback_sequential()
+    }
+
+    /// Execute the uncommitted block suffix sequentially.
+    pub fn fallback_sequential(&self) -> Result<(), GrevmError<DB::Error>> {
+        let mut results = self.results.lock();
+        let committed = results.len();
+        if committed == self.block_size {
+            return Ok(());
+        }
+
+        let mut commit_guard = CommitGuard::new(&self.state);
+        let state = commit_guard.state_mut();
+        let evm = build_evm(
+            state,
+            self.cfg.clone(),
+            self.env.clone(),
+            self.custom_precompiles.as_ref(),
+            self.config.delegated_safety.forbid_delegated_create,
+        );
+        let mut evm = evm;
+        // The planner describes the original full block, so suffix replay must keep global TxIds.
+        // `committed` must not rebase future-cost lookups.
+        let suffix = self.execute_sequential_suffix(committed, |txid, tx| {
+            reject_nonce_overflow(evm.db_mut(), self.cfg.disable_nonce_check, tx)?;
+            evm.ctx.set_tx(tx.clone());
+            let reserve_mode = ReserveMode::from_planner(txid, self.reserve_planner.as_deref());
+            let output: Result<ExecutionResult, EVMError<DB::Error>> =
+                GrevmHandler::new(reserve_mode, BeneficiaryMode::Immediate).run(&mut evm);
+            let state = evm.finalize();
+            output.inspect(|_| evm.db_mut().commit(state))
+        })?;
+        results.extend(suffix);
+        Ok(())
+    }
+
+    fn execute_sequential_suffix(
+        &self,
+        start: TxId,
+        mut transact: impl FnMut(TxId, &TxEnv) -> Result<ExecutionResult, EVMError<DB::Error>>,
+    ) -> Result<Vec<TxExecutionOutcome>, GrevmError<DB::Error>> {
+        let mut outcomes = Vec::with_capacity(self.block_size - start);
+        for txid in start..self.block_size {
+            let outcome = match transact(txid, &self.txs[txid]) {
+                Ok(result) => TxExecutionOutcome::Executed(result),
+                Err(EVMError::Transaction(error)) => {
+                    tracing::error!(
+                        target: "grevm::scheduler",
+                        block_number = %self.env.number,
+                        txid,
+                        ?error,
+                        "skipping invalid transaction during sequential fallback",
+                    );
+                    TxExecutionOutcome::Skipped(error)
+                }
+                Err(error) => return Err(GrevmError { txid, error }),
+            };
+            outcomes.push(outcome);
+            self.metrics.execution_cnt.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(outcomes)
+    }
+}
+
+fn reject_nonce_overflow<DB: DatabaseRef>(
+    db: &DB,
+    disable_nonce_check: bool,
+    tx: &TxEnv,
+) -> Result<(), EVMError<DB::Error>> {
+    if !disable_nonce_check &&
+        tx.nonce == u64::MAX &&
+        db.basic_ref(tx.caller)?.map_or(0, |info| info.nonce) == u64::MAX
+    {
+        return Err(InvalidTransaction::NonceOverflowInTransaction.into());
+    }
+    Ok(())
+}

--- a/src/scheduler/metrics.rs
+++ b/src/scheduler/metrics.rs
@@ -1,0 +1,92 @@
+use metrics_derive::Metrics;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Metrics)]
+#[metrics(scope = "grevm")]
+struct ExecuteMetrics {
+    /// Total transactions.
+    total_tx_cnt: metrics::Histogram,
+    /// Conflict incarnations.
+    conflict_cnt: metrics::Histogram,
+    /// Validation incarnations.
+    validation_cnt: metrics::Histogram,
+    /// Execution incarnations.
+    execution_cnt: metrics::Histogram,
+    /// Validation cursor resets.
+    reset_validation_idx_cnt: metrics::Histogram,
+    /// Dependency updates without work.
+    useless_dependent_update: metrics::Histogram,
+    /// Coinbase conflicts.
+    conflict_by_miner: metrics::Histogram,
+    /// EVM error conflicts.
+    conflict_by_error: metrics::Histogram,
+    /// Estimate read conflicts.
+    conflict_by_estimate: metrics::Histogram,
+    /// Version conflicts.
+    conflict_by_version: metrics::Histogram,
+    /// Transactions completed in one dependency attempt.
+    one_attempt_with_dependency: metrics::Histogram,
+    /// Transactions needing more than two dependency attempts.
+    more_attempts_with_dependency: metrics::Histogram,
+    /// Transactions without dependencies.
+    no_dependency_txs: metrics::Histogram,
+    /// Transactions with at least one conflict.
+    conflict_txs: metrics::Histogram,
+    /// Parallel execution time in nanoseconds.
+    execution_time: metrics::Histogram,
+    /// Commit time in nanoseconds.
+    commit_time: metrics::Histogram,
+    /// Total time in nanoseconds.
+    total_time: metrics::Histogram,
+}
+
+#[derive(Default)]
+pub(super) struct ExecuteMetricsCollector {
+    pub(super) total_tx_cnt: AtomicUsize,
+    pub(super) conflict_cnt: AtomicUsize,
+    pub(super) validation_cnt: AtomicUsize,
+    pub(super) execution_cnt: AtomicUsize,
+    pub(super) reset_validation_idx_cnt: AtomicUsize,
+    pub(super) useless_dependent_update: AtomicUsize,
+    pub(super) conflict_by_miner: AtomicUsize,
+    pub(super) conflict_by_error: AtomicUsize,
+    pub(super) conflict_by_estimate: AtomicUsize,
+    pub(super) conflict_by_version: AtomicUsize,
+    pub(super) one_attempt_with_dependency: AtomicUsize,
+    pub(super) more_attempts_with_dependency: AtomicUsize,
+    pub(super) no_dependency_txs: AtomicUsize,
+    pub(super) conflict_txs: AtomicUsize,
+    pub(super) execution_time: AtomicUsize,
+    pub(super) commit_time: AtomicUsize,
+    pub(super) total_time: AtomicUsize,
+}
+
+impl ExecuteMetricsCollector {
+    pub(super) fn report(&self) {
+        let metrics = ExecuteMetrics::default();
+        metrics.total_tx_cnt.record(load(&self.total_tx_cnt));
+        metrics.conflict_cnt.record(load(&self.conflict_cnt));
+        metrics.validation_cnt.record(load(&self.validation_cnt));
+        metrics.execution_cnt.record(load(&self.execution_cnt));
+        metrics.reset_validation_idx_cnt.record(load(&self.reset_validation_idx_cnt));
+        metrics.useless_dependent_update.record(load(&self.useless_dependent_update));
+        metrics.conflict_by_miner.record(load(&self.conflict_by_miner));
+        metrics.conflict_by_error.record(load(&self.conflict_by_error));
+        metrics.conflict_by_estimate.record(load(&self.conflict_by_estimate));
+        metrics.conflict_by_version.record(load(&self.conflict_by_version));
+        metrics.one_attempt_with_dependency.record(load(&self.one_attempt_with_dependency));
+        metrics.more_attempts_with_dependency.record(load(&self.more_attempts_with_dependency));
+        metrics.no_dependency_txs.record(load(&self.no_dependency_txs));
+        metrics.conflict_txs.record(load(&self.conflict_txs));
+        let execution_time = self.execution_time.load(Ordering::Relaxed);
+        if execution_time > 0 {
+            metrics.execution_time.record(execution_time as f64);
+        }
+        metrics.commit_time.record(load(&self.commit_time));
+        metrics.total_time.record(load(&self.total_time));
+    }
+}
+
+fn load(value: &AtomicUsize) -> f64 {
+    value.load(Ordering::Relaxed) as f64
+}

--- a/src/scheduler/tests.rs
+++ b/src/scheduler/tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use crate::InvalidTransaction;
+use revm_database::EmptyDB;
+use revm_primitives::{TxKind, U256, hardfork::SpecId};
+use revm_state::AccountInfo;
+
+fn empty_scheduler(num_txs: usize) -> Scheduler<EmptyDB> {
+    Scheduler::new(
+        CfgEnv::new_with_spec(SpecId::SHANGHAI),
+        BlockEnv::default(),
+        Arc::new(vec![TxEnv::default(); num_txs]),
+        ParallelState::new(EmptyDB::default(), true, false),
+        false,
+        None,
+    )
+}
+
+#[test]
+fn fatal_execution_abort_uses_recorded_txid_not_finality_idx() {
+    let scheduler = empty_scheduler(3);
+    *scheduler.tx_results[2].lock() = Some(TransactionResult {
+        read_set: Default::default(),
+        write_set: Default::default(),
+        execute_result: Err(EVMError::Custom("fatal execution error".to_owned())),
+    });
+    scheduler.abort(AbortReason::FatalEvmError(2));
+
+    let error = scheduler.post_execute().expect_err("fatal abort must be returned");
+    assert_eq!(scheduler.scheduler_ctx.finality_idx(), 0);
+    assert_eq!(error.txid, 2);
+    assert!(matches!(
+        error.error,
+        EVMError::Custom(message) if message == "fatal execution error"
+    ));
+}
+
+#[test]
+fn commit_abort_carries_error_without_using_tx_results() {
+    let scheduler = empty_scheduler(3);
+    scheduler.abort(AbortReason::CommitError(GrevmError {
+        txid: 1,
+        error: EVMError::Custom("commit error".to_owned()),
+    }));
+
+    let error = scheduler.post_execute().expect_err("commit abort must be returned");
+    assert_eq!(error.txid, 1);
+    assert!(matches!(
+        error.error,
+        EVMError::Custom(message) if message == "commit error"
+    ));
+    assert!(scheduler.tx_results.iter().all(|result| result.lock().is_none()));
+}
+
+#[test]
+fn parallel_error_replays_suffix_from_committed_prefix() {
+    let caller = Address::from([0xCA; 20]);
+    let receiver = Address::from([0xCB; 20]);
+    let state = ParallelState::new(EmptyDB::default(), true, false);
+    state.insert_account(
+        caller,
+        AccountInfo { balance: U256::from(1_000_000), nonce: 1, ..Default::default() },
+    );
+    let suffix_tx = TxEnv {
+        caller,
+        gas_limit: 21_000,
+        kind: TxKind::Call(receiver),
+        value: U256::from(1),
+        nonce: 1,
+        ..Default::default()
+    };
+    let scheduler = Scheduler::new(
+        CfgEnv::new_with_spec(SpecId::SHANGHAI),
+        BlockEnv::default(),
+        Arc::new(vec![TxEnv::default(), suffix_tx]),
+        state,
+        false,
+        None,
+    );
+    scheduler
+        .results
+        .lock()
+        .push(TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooLow { tx: 0, state: 1 }));
+    scheduler
+        .abort(AbortReason::ParallelError { txid: 1, message: "test parallel invariant failure" });
+
+    scheduler.post_execute().expect("sequential suffix replay must succeed");
+    let results = scheduler.results.lock();
+    assert_eq!(results.len(), 2);
+    assert!(matches!(results[1], TxExecutionOutcome::Executed(_)));
+}

--- a/src/test_utils/common/execute.rs
+++ b/src/test_utils/common/execute.rs
@@ -1,7 +1,10 @@
 use alloy_evm::{EthEvm, Evm, precompiles::PrecompilesMap};
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 
-use crate::{ParallelState, ParallelTakeBundle, Scheduler, TxExecutionOutcome};
+use crate::{
+    DelegatedSafetyConfig, GrevmConfig, ParallelState, ParallelTakeBundle, Scheduler,
+    TxExecutionOutcome,
+};
 use revm::{
     Context, DatabaseCommit, DatabaseRef, MainBuilder, MainContext,
     precompile::{PrecompileSpecId, Precompiles},
@@ -45,6 +48,15 @@ fn metrics_snapshotter() -> Option<&'static Snapshotter> {
         .as_ref()
 }
 
+/// Runtime configuration for revm-compatibility tests.
+///
+/// These tests use upstream revm as their oracle, so grevm-local delegated-account policies must
+/// stay disabled even if their defaults change later. Other scheduler settings still come from
+/// the environment for compatibility with the existing test and benchmark controls.
+fn revm_compatibility_config() -> GrevmConfig {
+    GrevmConfig::from_env().with_delegated_safety(DelegatedSafetyConfig::disabled())
+}
+
 pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
     assert!(
         left.contracts.keys().all(|k| right.contracts.contains_key(k)),
@@ -64,9 +76,7 @@ pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
     let right_state: BTreeMap<&Address, &BundleAccount> = right.state.iter().collect();
     assert_eq!(left_state.len(), right_state.len());
 
-    for ((addr1, account1), (addr2, account2)) in
-        left_state.into_iter().zip(right_state.into_iter())
-    {
+    for ((addr1, account1), (addr2, account2)) in left_state.into_iter().zip(right_state) {
         assert_eq!(addr1, addr2);
         assert_eq!(account1.info, account2.info, "Address: {:?}", addr1);
         assert_eq!(account1.original_info, account2.original_info, "Address: {:?}", addr1);
@@ -74,7 +84,7 @@ pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
         assert_eq!(account1.storage.len(), account2.storage.len());
         let left_storage: BTreeMap<&U256, &StorageSlot> = account1.storage.iter().collect();
         let right_storage: BTreeMap<&U256, &StorageSlot> = account2.storage.iter().collect();
-        for (s1, s2) in left_storage.into_iter().zip(right_storage.into_iter()) {
+        for (s1, s2) in left_storage.into_iter().zip(right_storage) {
             assert_eq!(s1, s2, "Address: {:?}", addr1);
         }
     }
@@ -95,7 +105,7 @@ pub fn compare_bundle_state(left: &BundleState, right: &BundleState) {
     assert_eq!(left.reverts_size, right.reverts_size, "reverts_size mismatch");
 }
 
-pub fn compare_execution_result(left: &Vec<ExecutionResult>, right: &Vec<TxExecutionOutcome>) {
+pub fn compare_execution_result(left: &[ExecutionResult], right: &[TxExecutionOutcome]) {
     for (i, (left_res, right_res)) in left.iter().zip(right.iter()).enumerate() {
         let TxExecutionOutcome::Executed(right_res) = right_res else {
             panic!("valid reference transaction {i} was unexpectedly skipped: {right_res:?}");
@@ -138,8 +148,7 @@ pub fn compare_evm_execute_with_spec<DB>(
     DB: DatabaseRef + Send + Sync + Debug,
     DB::Error: Send + Sync + Clone + Debug + 'static,
 {
-    let mut env = BlockEnv::default();
-    env.beneficiary = super::account::MINER_ADDRESS;
+    let env = BlockEnv { beneficiary: super::account::MINER_ADDRESS, ..Default::default() };
     let mut cfg = CfgEnv::new_with_spec(spec);
     cfg.disable_nonce_check = disable_nonce_check;
     // Synthetic blocks are constructed to always execute, so a sequential failure is itself a bug.
@@ -168,15 +177,22 @@ where
     let db = Arc::new(db);
     let txs = Arc::new(txs);
     let cfg = CfgEnv::new_with_spec(spec);
-    let mut env = BlockEnv::default();
-    env.beneficiary = super::account::MINER_ADDRESS;
+    let env = BlockEnv { beneficiary: super::account::MINER_ADDRESS, ..Default::default() };
 
     let (expected_outcomes, expected_bundle) =
         execute_revm_sequential_skipping_invalid(db.clone(), cfg.clone(), env.clone(), &txs)
             .unwrap_or_else(|error| panic!("sequential skip reference failed: {error:?}"));
 
     let state = ParallelState::new(db, true, true);
-    let scheduler = Scheduler::new(cfg, env, txs, state, with_hints, None);
+    let scheduler = Scheduler::new_with_config(
+        cfg,
+        env,
+        txs,
+        state,
+        with_hints,
+        None,
+        revm_compatibility_config(),
+    );
     scheduler.parallel_execute(Some(23)).expect("parallel execute failed");
     let (actual_outcomes, mut state) = scheduler.take_result_and_state();
     let actual_bundle = state.parallel_take_bundle(BundleRetention::Reverts);
@@ -225,7 +241,7 @@ where
     // 1) Sequential reference FIRST — if it errors, the inputs are unreplayable (not a grevm
     //    issue). Timed: the DB is already in memory, so this is pure execution, no I/O.
     let start = Instant::now();
-    let reth_result = match execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &*txs) {
+    let reth_result = match execute_revm_sequential(db.clone(), cfg.clone(), env.clone(), &txs) {
         Ok(result) => result,
         Err(e) => return ReplayOutcome::SequentialFailed(format!("{e:?}")),
     };
@@ -241,7 +257,15 @@ where
 
     let start = Instant::now();
     let state = ParallelState::new(db.clone(), true, true);
-    let executor = Scheduler::new(cfg.clone(), env.clone(), txs.clone(), state, with_hints, None);
+    let executor = Scheduler::new_with_config(
+        cfg.clone(),
+        env.clone(),
+        txs.clone(),
+        state,
+        with_hints,
+        None,
+        revm_compatibility_config(),
+    );
     // set determined partitions
     executor.parallel_execute(Some(23)).expect("parallel execute failed");
     let parallel = start.elapsed();

--- a/src/test_utils/erc20/mod.rs
+++ b/src/test_utils/erc20/mod.rs
@@ -22,6 +22,9 @@ pub type Bytecodes = HashMap<B256, Bytecode>;
 /// Mapping from block numbers to block hashes
 pub type BlockHashes = HashMap<u64, B256>;
 
+pub type Cluster =
+    (HashMap<Address, PlainAccount>, HashMap<B256, Bytecode>, Vec<Address>, Vec<Address>);
+
 // TODO: Better randomness control. Sometimes we want duplicates to test
 // dependent transactions, sometimes we want to guarantee non-duplicates
 // for independent benchmarks.
@@ -133,10 +136,7 @@ pub fn generate_erc20_batch(
 }
 
 /// Return a tuple of (state, bytecodes, eoa_addresses, sca_addresses)
-pub fn generate_cluster(
-    num_eoa: usize,
-    num_sca: usize,
-) -> (HashMap<Address, PlainAccount>, HashMap<B256, Bytecode>, Vec<Address>, Vec<Address>) {
+pub fn generate_cluster(num_eoa: usize, num_sca: usize) -> Cluster {
     let mut state = HashMap::default();
     let eoa_addresses: Vec<Address> = generate_addresses(num_eoa);
 
@@ -189,7 +189,7 @@ pub fn generate_contract_accounts(
         let gld_address = Address::new(rand::random());
         let mut gld_account =
             ERC20Token::new("Gold Token", "GLD", 18, 222_222_000_000_000_000_000_000u128)
-                .add_balances(&eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
+                .add_balances(eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
                 .build();
         bytecodes.insert(gld_account.info.code_hash, gld_account.info.code.take().unwrap());
         accounts.push((gld_address, gld_account));

--- a/src/test_utils/uniswap/mod.rs
+++ b/src/test_utils/uniswap/mod.rs
@@ -8,7 +8,7 @@ use revm::{
     bytecode::Bytecode,
     context::TxEnv,
     database::PlainAccount,
-    primitives::{Address, B256, Bytes, HashMap, TxKind, U256, uint},
+    primitives::{Address, B256, HashMap, TxKind, U256, uint},
     state::AccountInfo,
 };
 
@@ -39,14 +39,14 @@ pub fn generate_contract_accounts(
 
     let dai_account = ERC20Token::new("DAI", "DAI", 18, 222_222_000_000_000_000_000_000u128)
         .add_balances(&[pool_address], uint!(111_111_000_000_000_000_000_000_U256))
-        .add_balances(&eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
-        .add_allowances(&eoa_addresses, single_swap_address, uint!(1_000_000_000_000_000_000_U256))
+        .add_balances(eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
+        .add_allowances(eoa_addresses, single_swap_address, uint!(1_000_000_000_000_000_000_U256))
         .build();
 
     let usdc_account = ERC20Token::new("USDC", "USDC", 18, 222_222_000_000_000_000_000_000u128)
         .add_balances(&[pool_address], uint!(111_111_000_000_000_000_000_000_U256))
-        .add_balances(&eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
-        .add_allowances(&eoa_addresses, single_swap_address, uint!(1_000_000_000_000_000_000_U256))
+        .add_balances(eoa_addresses, uint!(1_000_000_000_000_000_000_U256))
+        .add_allowances(eoa_addresses, single_swap_address, uint!(1_000_000_000_000_000_000_U256))
         .build();
 
     let factory_account = UniswapV3Factory::new(owner)
@@ -91,14 +91,15 @@ pub fn generate_contract_accounts(
     let single_swap_account =
         SingleSwap::new(swap_router_address, dai_address, usdc_address).build();
 
-    let mut accounts = Vec::new();
-    accounts.push((weth9_address, weth9_account));
-    accounts.push((dai_address, dai_account));
-    accounts.push((usdc_address, usdc_account));
-    accounts.push((factory_address, factory_account));
-    accounts.push((pool_address, pool_account));
-    accounts.push((swap_router_address, swap_router_account));
-    accounts.push((single_swap_address, single_swap_account));
+    let mut accounts = vec![
+        (weth9_address, weth9_account),
+        (dai_address, dai_account),
+        (usdc_address, usdc_account),
+        (factory_address, factory_account),
+        (pool_address, pool_account),
+        (swap_router_address, swap_router_account),
+        (single_swap_address, single_swap_account),
+    ];
 
     let mut bytecodes = revm_primitives::HashMap::default();
     for (_, account) in accounts.iter_mut() {
@@ -155,7 +156,7 @@ pub fn generate_cluster(
                 gas_limit: GAS_LIMIT,
                 gas_price: 0x_b2d0_5e07u128,
                 kind: TxKind::Call(single_swap_address),
-                data: Bytes::from(data_bytes),
+                data: data_bytes,
                 nonce: nonce as u64,
                 ..TxEnv::default()
             })

--- a/src/tx_dependency.rs
+++ b/src/tx_dependency.rs
@@ -41,7 +41,7 @@ impl TxDependency {
                 .into_iter()
                 .map(|dep| Mutex::new(DependentState { onboard: true, dependency: dep }))
                 .collect(),
-            affect_txs: affect_txs.into_iter().map(|affects| Mutex::new(affects)).collect(),
+            affect_txs: affect_txs.into_iter().map(Mutex::new).collect(),
             index: AtomicUsize::new(0),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,29 @@
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use std::{
+    cmp::min,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    thread,
+};
+
+/// Divide a range into disjoint partitions and process them through Rayon's worker pool.
+pub fn fork_join_util<'scope, F>(num_elements: usize, num_partitions: Option<usize>, f: F)
+where
+    F: Fn(usize, usize, usize) + Send + Sync + 'scope,
+{
+    if num_elements == 0 {
+        return;
+    }
+    let partitions = num_partitions
+        .unwrap_or_else(|| thread::available_parallelism().map_or(8, |value| value.get()));
+    assert!(partitions > 0, "fork-join partition count must be greater than zero");
+    let remaining = num_elements % partitions;
+    let chunk_size = num_elements / partitions;
+    (0..partitions).into_par_iter().for_each(|index| {
+        let start = chunk_size * index + min(index, remaining);
+        let end = start + chunk_size + usize::from(index < remaining);
+        f(start, end, index);
+    });
+}
 
 #[derive(Debug)]
 pub(crate) struct ContinuousDetectSet {
@@ -53,5 +78,28 @@ impl ContinuousDetectSet {
             self.check_continuous();
         }
         self.continuous_idx.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn fork_join_covers_each_index_exactly_once() {
+        let visits = Mutex::new(vec![0usize; 17]);
+        fork_join_util(17, Some(4), |start, end, _| {
+            let mut visits = visits.lock().unwrap();
+            for visit in &mut visits[start..end] {
+                *visit += 1;
+            }
+        });
+        assert!(visits.into_inner().unwrap().into_iter().all(|count| count == 1));
+    }
+
+    #[test]
+    fn fork_join_accepts_empty_ranges() {
+        fork_join_util(0, Some(0), |_, _, _| unreachable!());
     }
 }

--- a/tests/delegated_safety.rs
+++ b/tests/delegated_safety.rs
@@ -1,0 +1,809 @@
+#![allow(missing_docs)]
+
+//! End-to-end tests for grevm's opt-in EIP-7702 delegated-account safety policy.
+
+use alloy_evm::precompiles::DynPrecompile;
+use grevm::{
+    DelegatedSafetyConfig, GrevmConfig, InvalidTransaction, ParallelState, ParallelTakeBundle,
+    Scheduler, TxExecutionOutcome,
+    test_utils::{
+        TRANSFER_GAS_LIMIT,
+        common::{account, execute, storage::InMemoryDB},
+    },
+};
+use revm::precompile::{PrecompileId, PrecompileOutput};
+use revm_context::{
+    BlockEnv, CfgEnv, TxEnv,
+    either::Either,
+    result::ExecutionResult,
+    transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization},
+};
+use revm_database::{PlainAccount, states::bundle_state::BundleRetention};
+use revm_primitives::{
+    Address, Bytes, HashMap, KECCAK_EMPTY, TxKind, U256, alloy_primitives::U160, hardfork::SpecId,
+};
+use revm_state::{AccountInfo, Bytecode};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+const BLOCK_SIZE: usize = 100;
+const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
+
+fn authority() -> Address {
+    Address::from(U160::from(900_000))
+}
+
+fn receiver() -> Address {
+    Address::from(U160::from(900_001))
+}
+
+fn reserve_authority() -> Address {
+    Address::from(U160::from(900_002))
+}
+
+fn delegate_target() -> Address {
+    Address::from(U160::from(910_000))
+}
+
+fn contract_target() -> Address {
+    Address::from(U160::from(910_001))
+}
+
+fn reserve_delegate_target() -> Address {
+    Address::from(U160::from(910_002))
+}
+
+fn eoa_account(balance: u128, nonce: u64) -> PlainAccount {
+    PlainAccount {
+        info: AccountInfo {
+            balance: U256::from(balance),
+            nonce,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+        },
+        storage: Default::default(),
+    }
+}
+
+fn contract_account(code: &Bytecode) -> PlainAccount {
+    PlainAccount {
+        info: AccountInfo {
+            nonce: 1,
+            code_hash: code.hash_slow(),
+            code: Some(code.clone()),
+            ..Default::default()
+        },
+        storage: Default::default(),
+    }
+}
+
+fn database(target_code: Bytecode) -> InMemoryDB {
+    let mut accounts = account::mock_block_accounts(BLOCK_SIZE);
+    accounts.insert(authority(), eoa_account(ONE_ETHER, 0));
+    accounts.insert(receiver(), eoa_account(ONE_ETHER, 0));
+    accounts.insert(delegate_target(), contract_account(&target_code));
+    let mut bytecodes = HashMap::default();
+    bytecodes.insert(target_code.hash_slow(), target_code);
+    InMemoryDB::new(accounts, bytecodes, Default::default())
+}
+
+fn insert_contract(db: &mut InMemoryDB, address: Address, code: Bytecode) {
+    db.accounts.insert(address, contract_account(&code));
+    db.bytecodes.insert(code.hash_slow(), code);
+}
+
+fn delegate_authority(db: &mut InMemoryDB) {
+    let designator = Bytecode::new_eip7702(delegate_target());
+    db.bytecodes.insert(designator.hash_slow(), designator.clone());
+    let account = &mut db.accounts.get_mut(&authority()).unwrap().info;
+    account.code_hash = designator.hash_slow();
+    account.code = Some(designator);
+}
+
+fn padding_tx(index: usize) -> TxEnv {
+    let caller = account::mock_eoa_address(index);
+    TxEnv {
+        caller,
+        kind: TxKind::Call(caller),
+        value: U256::from(1),
+        gas_limit: TRANSFER_GAS_LIMIT,
+        gas_price: 1,
+        nonce: 1,
+        ..Default::default()
+    }
+}
+
+fn delegated_tx_for(
+    index: usize,
+    authority: Address,
+    code_address: Address,
+    authorization_nonce: u64,
+) -> TxEnv {
+    let authorization =
+        Authorization { chain_id: U256::ZERO, address: code_address, nonce: authorization_nonce };
+    TxEnv {
+        tx_type: 4,
+        caller: account::mock_eoa_address(index),
+        kind: TxKind::Call(authority),
+        gas_limit: 400_000,
+        gas_price: 1,
+        nonce: 1,
+        authorization_list: vec![Either::Right(RecoveredAuthorization::new_unchecked(
+            authorization,
+            RecoveredAuthority::Valid(authority),
+        ))],
+        ..Default::default()
+    }
+}
+
+fn delegated_tx(index: usize, code_address: Address) -> TxEnv {
+    delegated_tx_for(index, authority(), code_address, 0)
+}
+
+fn account_tx(caller: Address, nonce: u64, target: Address) -> TxEnv {
+    TxEnv {
+        caller,
+        kind: TxKind::Call(target),
+        gas_limit: TRANSFER_GAS_LIMIT,
+        gas_price: 1,
+        nonce,
+        ..Default::default()
+    }
+}
+
+fn authority_tx(nonce: u64) -> TxEnv {
+    account_tx(authority(), nonce, receiver())
+}
+
+fn ordinary_call_tx(index: usize, target: Address) -> TxEnv {
+    TxEnv {
+        caller: account::mock_eoa_address(index),
+        kind: TxKind::Call(target),
+        gas_limit: 400_000,
+        gas_price: 1,
+        nonce: 1,
+        ..Default::default()
+    }
+}
+
+fn create_opcode_code(opcode: u8) -> Bytecode {
+    let code = match opcode {
+        0xf0 => vec![
+            0x60, 0x00, // size
+            0x60, 0x00, // offset
+            0x60, 0x00, // value
+            0xf0, // CREATE
+            0x50, // POP
+            0x00, // STOP
+        ],
+        0xf5 => vec![
+            0x60, 0x00, // salt
+            0x60, 0x00, // size
+            0x60, 0x00, // offset
+            0x60, 0x00, // value
+            0xf5, // CREATE2
+            0x50, // POP
+            0x00, // STOP
+        ],
+        _ => unreachable!("only CREATE and CREATE2 are supported"),
+    };
+    Bytecode::new_raw(code.into())
+}
+
+fn call_code(target: Address, value_opcode: &[u8]) -> Bytecode {
+    let mut code = Vec::new();
+    append_call(&mut code, target, value_opcode);
+    code.push(0x00); // STOP
+    Bytecode::new_raw(code.into())
+}
+
+fn append_call(code: &mut Vec<u8>, target: Address, value_opcode: &[u8]) {
+    code.extend_from_slice(&[
+        0x60, 0x00, // return size
+        0x60, 0x00, // return offset
+        0x60, 0x00, // args size
+        0x60, 0x00, // args offset
+    ]);
+    code.extend_from_slice(value_opcode);
+    code.push(0x73); // PUSH20
+    code.extend_from_slice(target.as_slice());
+    code.extend_from_slice(&[0x62, 0x0f, 0x42, 0x40, 0xf1, 0x50]); // CALL, POP
+}
+
+fn signal_then_value_call_code(signal: Address, target: Address, value: u64) -> Bytecode {
+    let mut code = Vec::new();
+    append_call(&mut code, signal, &[0x60, 0x00]);
+    let mut value_opcode = vec![0x67]; // PUSH8
+    value_opcode.extend_from_slice(&value.to_be_bytes());
+    append_call(&mut code, target, &value_opcode);
+    code.push(0x00); // STOP
+    Bytecode::new_raw(code.into())
+}
+
+fn drain_code(target: Address) -> Bytecode {
+    call_code(target, &[0x47]) // SELFBALANCE
+}
+
+fn fixed_value_call_code(target: Address, value: u64) -> Bytecode {
+    let mut push = vec![0x67]; // PUSH8
+    push.extend_from_slice(&value.to_be_bytes());
+    call_code(target, &push)
+}
+
+fn zero_value_call_code(target: Address) -> Bytecode {
+    call_code(target, &[0x60, 0x00])
+}
+
+fn selfdestruct_code(target: Address) -> Bytecode {
+    let mut code = vec![0x73];
+    code.extend_from_slice(target.as_slice());
+    code.push(0xff);
+    Bytecode::new_raw(code.into())
+}
+
+fn execute_block(
+    db: InMemoryDB,
+    txs: Vec<TxEnv>,
+    safety: DelegatedSafetyConfig,
+    force_sequential: bool,
+) -> (Vec<TxExecutionOutcome>, revm_database::BundleState) {
+    execute_block_with_precompiles(db, txs, safety, force_sequential, 23, None)
+}
+
+fn execute_block_with_precompiles(
+    db: InMemoryDB,
+    txs: Vec<TxEnv>,
+    safety: DelegatedSafetyConfig,
+    force_sequential: bool,
+    concurrency_level: usize,
+    custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
+) -> (Vec<TxExecutionOutcome>, revm_database::BundleState) {
+    let txs = Arc::new(txs);
+    let block = BlockEnv { beneficiary: account::MINER_ADDRESS, ..Default::default() };
+    let state = ParallelState::new(Arc::new(db), true, true);
+    let config = GrevmConfig {
+        concurrency_level,
+        force_sequential,
+        min_parallel_txs: 0,
+        delegated_safety: safety,
+    };
+    let scheduler = Scheduler::new_with_config(
+        CfgEnv::new_with_spec(SpecId::PRAGUE),
+        block,
+        txs,
+        state,
+        false,
+        custom_precompiles,
+        config,
+    );
+    scheduler.execute().expect("block execution failed");
+    let (outcomes, mut state) = scheduler.take_result_and_state();
+    let bundle = state.parallel_take_bundle(BundleRetention::Reverts);
+    (outcomes, bundle)
+}
+
+fn execute_safety(
+    db: InMemoryDB,
+    txs: Vec<TxEnv>,
+    force_sequential: bool,
+) -> (Vec<TxExecutionOutcome>, revm_database::BundleState) {
+    execute_block(db, txs, DelegatedSafetyConfig::enabled(), force_sequential)
+}
+
+fn final_info<'a>(
+    db: &'a InMemoryDB,
+    bundle: &'a revm_database::BundleState,
+    address: Address,
+) -> &'a AccountInfo {
+    bundle
+        .state
+        .get(&address)
+        .and_then(|account| account.info.as_ref())
+        .unwrap_or_else(|| &db.accounts.get(&address).unwrap().info)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutcomeKind {
+    Success,
+    Revert,
+    Halt,
+    NonceTooLow,
+    LackOfFund,
+}
+
+fn assert_outcome(outcome: &TxExecutionOutcome, expected: OutcomeKind, context: &str) {
+    let matches = matches!(
+        (outcome, expected),
+        (TxExecutionOutcome::Executed(ExecutionResult::Success { .. }), OutcomeKind::Success) |
+            (TxExecutionOutcome::Executed(ExecutionResult::Revert { .. }), OutcomeKind::Revert) |
+            (TxExecutionOutcome::Executed(ExecutionResult::Halt { .. }), OutcomeKind::Halt) |
+            (
+                TxExecutionOutcome::Skipped(InvalidTransaction::NonceTooLow { .. }),
+                OutcomeKind::NonceTooLow
+            ) |
+            (
+                TxExecutionOutcome::Skipped(InvalidTransaction::LackOfFundForMaxFee { .. }),
+                OutcomeKind::LackOfFund
+            )
+    );
+    assert!(matches, "{context}: expected {expected:?}, got {outcome:?}");
+}
+
+fn execute_in_both_modes(
+    db: InMemoryDB,
+    txs: Vec<TxEnv>,
+    safety: DelegatedSafetyConfig,
+) -> (Vec<TxExecutionOutcome>, revm_database::BundleState) {
+    let parallel = execute_block(db.clone(), txs.clone(), safety, false);
+    let sequential = execute_block(db, txs, safety, true);
+    assert_eq!(parallel.0, sequential.0);
+    execute::compare_bundle_state(&sequential.1, &parallel.1);
+    parallel
+}
+
+fn retry_probe_precompiles(
+    executions: Arc<AtomicUsize>,
+    blocker: Address,
+    probe: Address,
+    coordinate_parallel_attempt: bool,
+) -> Arc<Vec<(Address, DynPrecompile)>> {
+    let blocker_executions = executions.clone();
+    let blocker_precompile = DynPrecompile::new_stateful(
+        PrecompileId::Custom("grevm-test-retry-blocker".into()),
+        move |_| {
+            if coordinate_parallel_attempt {
+                while blocker_executions.load(Ordering::Acquire) == 0 {
+                    thread::yield_now();
+                }
+                // The probe runs near the start of the delegated call. Keep tx 0 open long enough
+                // for tx 1 to publish its stale speculative result before tx 0 publishes its write.
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(PrecompileOutput::new(0, Bytes::new()))
+        },
+    );
+    let probe_precompile = DynPrecompile::new_stateful(
+        PrecompileId::Custom("grevm-test-retry-probe".into()),
+        move |_| {
+            executions.fetch_add(1, Ordering::AcqRel);
+            Ok(PrecompileOutput::new(0, Bytes::new()))
+        },
+    );
+    Arc::new(vec![(blocker, blocker_precompile), (probe, probe_precompile)])
+}
+
+#[test]
+fn delegated_create_and_balance_transfer_follow_four_policy_combinations() {
+    let policy_cases = [
+        ("disabled", DelegatedSafetyConfig::disabled()),
+        ("create-only", DelegatedSafetyConfig::create_only()),
+        ("reserve-only", DelegatedSafetyConfig::reserve_only()),
+        ("enabled", DelegatedSafetyConfig::enabled()),
+    ];
+
+    for (opcode_name, opcode) in [("CREATE", 0xf0), ("CREATE2", 0xf5)] {
+        for (policy_name, safety) in policy_cases {
+            // Two independent delegated accounts make both policy decisions observable in the
+            // same block. A executes CREATE/CREATE2; B drains its balance before a later B tx.
+            let mut db = database(create_opcode_code(opcode));
+            db.accounts.insert(reserve_authority(), eoa_account(ONE_ETHER, 0));
+            insert_contract(&mut db, reserve_delegate_target(), drain_code(receiver()));
+
+            let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+            txs[10] = delegated_tx(10, delegate_target());
+            txs[20] = authority_tx(1);
+            txs[21] = authority_tx(2);
+            txs[30] = delegated_tx_for(30, reserve_authority(), reserve_delegate_target(), 0);
+            txs[31] = account_tx(reserve_authority(), 1, receiver());
+
+            let context = format!("{opcode_name}/{policy_name}");
+            let (outcomes, bundle) = execute_in_both_modes(db.clone(), txs, safety);
+
+            let create_kind = if safety.forbid_delegated_create {
+                OutcomeKind::Halt
+            } else {
+                OutcomeKind::Success
+            };
+            assert_outcome(&outcomes[10], create_kind, &format!("{context}: delegated create"));
+            let stale_nonce_kind = if safety.forbid_delegated_create {
+                OutcomeKind::Success
+            } else {
+                OutcomeKind::NonceTooLow
+            };
+            assert_outcome(&outcomes[20], stale_nonce_kind, &format!("{context}: nonce 1 suffix"));
+            assert_outcome(
+                &outcomes[21],
+                OutcomeKind::Success,
+                &format!("{context}: nonce 2 suffix"),
+            );
+
+            let transfer_kind = if safety.reserve_delegated_balance {
+                OutcomeKind::Revert
+            } else {
+                OutcomeKind::Success
+            };
+            assert_outcome(
+                &outcomes[30],
+                transfer_kind,
+                &format!("{context}: delegated balance drain"),
+            );
+            let funded_suffix_kind = if safety.reserve_delegated_balance {
+                OutcomeKind::Success
+            } else {
+                OutcomeKind::LackOfFund
+            };
+            assert_outcome(
+                &outcomes[31],
+                funded_suffix_kind,
+                &format!("{context}: balance-dependent suffix"),
+            );
+
+            assert_eq!(final_info(&db, &bundle, authority()).nonce, 3, "{context}");
+            let expected_reserve_nonce = if safety.reserve_delegated_balance { 2 } else { 1 };
+            assert_eq!(
+                final_info(&db, &bundle, reserve_authority()).nonce,
+                expected_reserve_nonce,
+                "{context}"
+            );
+            let expected_reserve_balance = if safety.reserve_delegated_balance {
+                U256::from(ONE_ETHER - TRANSFER_GAS_LIMIT as u128)
+            } else {
+                U256::ZERO
+            };
+            assert_eq!(
+                final_info(&db, &bundle, reserve_authority()).balance,
+                expected_reserve_balance,
+                "{context}"
+            );
+            let expected_receiver_balance = if safety.reserve_delegated_balance {
+                U256::from(ONE_ETHER)
+            } else {
+                U256::from(2 * ONE_ETHER)
+            };
+            assert_eq!(
+                final_info(&db, &bundle, receiver()).balance,
+                expected_receiver_balance,
+                "{context}"
+            );
+            assert!(
+                final_info(&db, &bundle, account::mock_eoa_address(30)).balance <
+                    U256::from(ONE_ETHER),
+                "{context}: the sponsored delegated attempt must remain charged"
+            );
+        }
+    }
+}
+
+#[test]
+fn reserve_retry_reexecutes_after_a_stale_speculative_balance_read() {
+    const INITIAL_BALANCE: u64 = 150;
+    const EARLIER_ROOT_TRANSFER: u64 = 100;
+    const DELEGATED_TRANSFER: u64 = 120;
+    const FUTURE_VALUE: u64 = 40;
+
+    let blocker = Address::from(U160::from(920_000));
+    let probe = Address::from(U160::from(920_001));
+    let mut db = database(signal_then_value_call_code(probe, receiver(), DELEGATED_TRANSFER));
+    delegate_authority(&mut db);
+    db.accounts.get_mut(&authority()).unwrap().info.balance = U256::from(INITIAL_BALANCE);
+
+    let mut earlier = account_tx(authority(), 0, blocker);
+    earlier.value = U256::from(EARLIER_ROOT_TRANSFER);
+    earlier.gas_price = 0;
+    let mut delegated = ordinary_call_tx(1, authority());
+    delegated.gas_price = 0;
+    let mut future = account_tx(authority(), 1, receiver());
+    future.value = U256::from(FUTURE_VALUE);
+    future.gas_price = 0;
+    let txs = vec![earlier, delegated, future];
+
+    // tx 0 blocks inside a custom precompile until tx 1 has entered its delegated code. Tx 1
+    // therefore first reads A.balance=150 and tentatively hits the reserve guard after sending
+    // 120. Once tx 0 publishes its root transfer, MV validation invalidates that incarnation.
+    // Re-execution sees A.balance=50, so the 120-value CALL fails without a debit and tx 1
+    // succeeds.
+    let parallel_executions = Arc::new(AtomicUsize::new(0));
+    let parallel = execute_block_with_precompiles(
+        db.clone(),
+        txs.clone(),
+        DelegatedSafetyConfig::reserve_only(),
+        false,
+        2,
+        Some(retry_probe_precompiles(parallel_executions.clone(), blocker, probe, true)),
+    );
+    assert!(
+        parallel_executions.load(Ordering::Acquire) >= 2,
+        "the delegated transaction must execute speculatively and then retry"
+    );
+
+    let sequential_executions = Arc::new(AtomicUsize::new(0));
+    let sequential = execute_block_with_precompiles(
+        db.clone(),
+        txs,
+        DelegatedSafetyConfig::reserve_only(),
+        true,
+        1,
+        Some(retry_probe_precompiles(sequential_executions.clone(), blocker, probe, false)),
+    );
+    assert_eq!(
+        sequential_executions.load(Ordering::Acquire),
+        1,
+        "the ordered reference executes the delegated transaction once"
+    );
+
+    assert_eq!(parallel.0, sequential.0);
+    execute::compare_bundle_state(&sequential.1, &parallel.1);
+    assert_outcome(&parallel.0[0], OutcomeKind::Success, "earlier root transfer");
+    assert_outcome(&parallel.0[1], OutcomeKind::Success, "retried delegated transaction");
+    assert_outcome(&parallel.0[2], OutcomeKind::Success, "funded suffix");
+    assert_eq!(final_info(&db, &parallel.1, authority()).balance, U256::from(10));
+}
+
+#[test]
+fn ordinary_create_and_create2_remain_allowed_with_both_policies_enabled() {
+    for (opcode_name, opcode) in [("CREATE", 0xf0), ("CREATE2", 0xf5)] {
+        for through_delegate in [false, true] {
+            let target_code = if through_delegate {
+                zero_value_call_code(contract_target())
+            } else {
+                Bytecode::new_raw(vec![0x00].into())
+            };
+            let mut db = database(target_code);
+            insert_contract(&mut db, contract_target(), create_opcode_code(opcode));
+            let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+            txs[10] = if through_delegate {
+                delegated_tx(10, delegate_target())
+            } else {
+                ordinary_call_tx(10, contract_target())
+            };
+
+            let (outcomes, bundle) = execute_safety(db.clone(), txs, false);
+            let path = if through_delegate { "delegated parent" } else { "direct call" };
+            assert_outcome(&outcomes[10], OutcomeKind::Success, &format!("{opcode_name}/{path}"));
+            assert_eq!(
+                final_info(&db, &bundle, contract_target()).nonce,
+                2,
+                "{opcode_name}/{path}: the ordinary contract must execute its create opcode"
+            );
+        }
+    }
+}
+
+#[test]
+fn account_without_future_transactions_can_drain_its_balance() {
+    let db = database(drain_code(receiver()));
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+
+    let (outcomes, bundle) = execute_safety(db.clone(), txs, false);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Success { .. })));
+    assert_eq!(final_info(&db, &bundle, authority()).balance, U256::ZERO);
+}
+
+#[test]
+fn ordinary_transaction_value_from_delegated_sender_is_not_reserved() {
+    let mut db = database(Bytecode::new_raw(vec![0x00].into()));
+    delegate_authority(&mut db);
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    let mut drain = authority_tx(0);
+    drain.value = U256::from(ONE_ETHER - TRANSFER_GAS_LIMIT as u128);
+    txs[10] = drain;
+    txs[11] = authority_tx(1);
+
+    let (outcomes, bundle) =
+        execute_block(db.clone(), txs, DelegatedSafetyConfig::reserve_only(), false);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Success { .. })));
+    assert!(matches!(
+        outcomes[11],
+        TxExecutionOutcome::Skipped(InvalidTransaction::LackOfFundForMaxFee { .. })
+    ));
+    assert_eq!(final_info(&db, &bundle, authority()).balance, U256::ZERO);
+    assert_eq!(
+        final_info(&db, &bundle, receiver()).balance,
+        U256::from(2 * ONE_ETHER - TRANSFER_GAS_LIMIT as u128)
+    );
+}
+
+#[test]
+fn delegated_reserve_accepts_ample_and_exact_balances_but_reverts_below_boundary() {
+    // The two suffix transactions each cost exactly 100_000 value + 21_000 gas, so their
+    // max_balance_spending() sum and actual total cost are both 242_000.
+    for (case, drain, expected, expected_final_balance) in [
+        ("ample", 700_000, OutcomeKind::Success, 58_000),
+        ("exact", 758_000, OutcomeKind::Success, 0),
+        ("one wei short", 758_001, OutcomeKind::Revert, 758_000),
+    ] {
+        let mut db = database(fixed_value_call_code(receiver(), drain));
+        db.accounts.get_mut(&authority()).unwrap().info.balance = U256::from(1_000_000);
+        let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+        txs[10] = delegated_tx(10, delegate_target());
+        let mut first = authority_tx(1);
+        first.value = U256::from(100_000);
+        txs[11] = first;
+        let mut second = authority_tx(2);
+        second.value = U256::from(100_000);
+        txs[12] = second;
+
+        let (outcomes, bundle) = execute_safety(db.clone(), txs, false);
+        assert_outcome(&outcomes[10], expected, case);
+        assert_outcome(&outcomes[11], OutcomeKind::Success, case);
+        assert_outcome(&outcomes[12], OutcomeKind::Success, case);
+        assert_eq!(
+            final_info(&db, &bundle, authority()).balance,
+            U256::from(expected_final_balance),
+            "{case}"
+        );
+    }
+}
+
+#[test]
+fn disabled_reserve_allows_max_cost_overestimate_when_actual_cost_is_affordable() {
+    const INITIAL_BALANCE: u64 = 1_000_000;
+    const DELEGATED_SPEND: u64 = 850_000;
+    const FUTURE_GAS_LIMIT: u64 = 100_000;
+
+    let mut db = database(fixed_value_call_code(receiver(), DELEGATED_SPEND));
+    db.accounts.get_mut(&authority()).unwrap().info.balance = U256::from(INITIAL_BALANCE);
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+    for (txid, nonce) in [(11, 1), (12, 2)] {
+        let mut future = authority_tx(nonce);
+        future.gas_limit = FUTURE_GAS_LIMIT;
+        txs[txid] = future;
+    }
+
+    // The suffix max_balance_spending() sum is 200k, but each EOA transfer actually uses only 21k.
+    // Leaving 150k lets each tx separately pass its 100k upfront check, then the first refund makes
+    // enough balance available for the second. The real sequential total is only 42k.
+    let (disabled, disabled_bundle) =
+        execute_block(db.clone(), txs.clone(), DelegatedSafetyConfig::disabled(), false);
+    assert_outcome(&disabled[10], OutcomeKind::Success, "reserve disabled/delegated");
+    assert_outcome(&disabled[11], OutcomeKind::Success, "reserve disabled/future 1");
+    assert_outcome(&disabled[12], OutcomeKind::Success, "reserve disabled/future 2");
+    assert_eq!(
+        final_info(&db, &disabled_bundle, authority()).balance,
+        U256::from(INITIAL_BALANCE - DELEGATED_SPEND - 2 * TRANSFER_GAS_LIMIT)
+    );
+
+    // The enabled policy intentionally uses the conservative maximum and rejects the same debit.
+    let (enabled, enabled_bundle) =
+        execute_block(db.clone(), txs, DelegatedSafetyConfig::reserve_only(), false);
+    assert_outcome(&enabled[10], OutcomeKind::Revert, "reserve enabled/delegated");
+    assert_outcome(&enabled[11], OutcomeKind::Success, "reserve enabled/future 1");
+    assert_outcome(&enabled[12], OutcomeKind::Success, "reserve enabled/future 2");
+    assert_eq!(
+        final_info(&db, &enabled_bundle, authority()).balance,
+        U256::from(INITIAL_BALANCE - 2 * TRANSFER_GAS_LIMIT)
+    );
+}
+
+#[test]
+fn reserve_revert_preserves_eip7702_authorization_refund() {
+    let db = database(drain_code(receiver()));
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+    txs[11] = authority_tx(1);
+
+    // Both executions take the same EIP-7702 authorization and delegated CALL path. The enabled
+    // policy changes the final outcome to REVERT, but the pre-execution authorization refund is
+    // independent of the rolled-back balance transfer and therefore keeps gas usage identical.
+    let (standard, _) =
+        execute_block(db.clone(), txs.clone(), DelegatedSafetyConfig::disabled(), false);
+    let (reserve, _) = execute_block(db, txs, DelegatedSafetyConfig::reserve_only(), false);
+    assert_outcome(&standard[10], OutcomeKind::Success, "reserve disabled");
+    assert_outcome(&reserve[10], OutcomeKind::Revert, "reserve enabled");
+    let TxExecutionOutcome::Executed(standard) = &standard[10] else {
+        unreachable!("outcome checked above")
+    };
+    let TxExecutionOutcome::Executed(reserve) = &reserve[10] else {
+        unreachable!("outcome checked above")
+    };
+    assert_eq!(standard.gas_used(), reserve.gas_used());
+}
+
+#[test]
+fn reserve_does_not_require_more_than_the_pre_debit_balance() {
+    let mut db = database(fixed_value_call_code(contract_target(), 1));
+    insert_contract(&mut db, contract_target(), selfdestruct_code(authority()));
+    db.accounts.get_mut(&authority()).unwrap().info.balance = U256::from(200_000);
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+    let mut first = authority_tx(1);
+    first.value = U256::from(100_000);
+    txs[11] = first;
+    let mut second = authority_tx(2);
+    second.value = U256::from(100_000);
+    txs[12] = second;
+
+    let (outcomes, _) = execute_safety(db, txs, false);
+    // The delegated CALL debits one wei, and the callee's SELFDESTRUCT immediately returns it.
+    // A starts below the conservative 242k suffix, so required=min(200k, 242k)=200k.
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Success { .. })));
+    assert!(matches!(outcomes[11], TxExecutionOutcome::Executed(_)));
+    assert!(matches!(
+        outcomes[12],
+        TxExecutionOutcome::Skipped(InvalidTransaction::LackOfFundForMaxFee { .. })
+    ));
+}
+
+#[test]
+fn top_level_create_calling_a_delegated_account_keeps_creator_nonce_on_reserve_revert() {
+    let mut db = database(drain_code(receiver()));
+    delegate_authority(&mut db);
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    let creator = account::mock_eoa_address(10);
+    txs[10] = TxEnv {
+        caller: creator,
+        kind: TxKind::Create,
+        data: zero_value_call_code(authority()).original_bytes(),
+        gas_limit: 400_000,
+        gas_price: 1,
+        nonce: 1,
+        ..Default::default()
+    };
+    txs[11] = authority_tx(0);
+
+    let (outcomes, bundle) =
+        execute_block(db.clone(), txs, DelegatedSafetyConfig::reserve_only(), false);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Revert { .. })));
+    assert!(matches!(outcomes[11], TxExecutionOutcome::Executed(_)));
+    assert_eq!(final_info(&db, &bundle, creator).nonce, 2);
+}
+
+#[test]
+fn reverted_inner_debit_does_not_create_false_reserve_violation() {
+    let mut db = database(drain_code(contract_target()));
+    insert_contract(
+        &mut db,
+        contract_target(),
+        Bytecode::new_raw(vec![0x60, 0, 0x60, 0, 0xfd].into()),
+    );
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+
+    let (outcomes, bundle) = execute_safety(db.clone(), txs, false);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Success { .. })));
+    assert_eq!(final_info(&db, &bundle, authority()).balance, U256::from(ONE_ETHER));
+}
+
+#[test]
+fn selfdestruct_is_subject_to_the_same_reserve_policy() {
+    let db = database(selfdestruct_code(receiver()));
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+    txs[11] = authority_tx(1);
+
+    let (outcomes, bundle) = execute_safety(db.clone(), txs, false);
+    assert!(matches!(outcomes[10], TxExecutionOutcome::Executed(ExecutionResult::Revert { .. })));
+    assert!(matches!(outcomes[11], TxExecutionOutcome::Executed(_)));
+    assert_eq!(
+        final_info(&db, &bundle, authority()).balance,
+        U256::from(ONE_ETHER - TRANSFER_GAS_LIMIT as u128)
+    );
+}
+
+#[test]
+fn reserve_tracking_does_not_change_selfdestruct_gas() {
+    let db = database(selfdestruct_code(receiver()));
+    let mut txs: Vec<_> = (0..BLOCK_SIZE).map(padding_tx).collect();
+    txs[10] = delegated_tx(10, delegate_target());
+
+    let (standard, standard_bundle) =
+        execute_block(db.clone(), txs.clone(), DelegatedSafetyConfig::disabled(), false);
+    let (reserve, reserve_bundle) =
+        execute_block(db, txs, DelegatedSafetyConfig::reserve_only(), false);
+    let TxExecutionOutcome::Executed(standard) = &standard[10] else {
+        panic!("selfdestruct transaction must execute on the standard path")
+    };
+    let TxExecutionOutcome::Executed(reserve) = &reserve[10] else {
+        panic!("selfdestruct transaction must execute on the reserve path")
+    };
+    assert_eq!(standard.gas_used(), reserve.gas_used());
+    execute::compare_bundle_state(&standard_bundle, &reserve_bundle);
+}

--- a/tests/eip-7702.rs
+++ b/tests/eip-7702.rs
@@ -295,7 +295,7 @@ fn delegated_balance_drain_makes_following_tx_invalid() {
 
 /// Positive control: a single delegation followed by a CALL. Exercises the whole 7702
 /// plumbing end-to-end and must agree with the sequential reference both before and after
-/// the storage.rs fix.
+/// the CacheDB code-publication fix.
 #[test]
 fn single_delegation_then_call() {
     let mut txs: Vec<TxEnv> = (0..BLOCK_SIZE).map(padding_tx).collect();

--- a/tests/native_transfers.rs
+++ b/tests/native_transfers.rs
@@ -164,8 +164,7 @@ fn basefee_error_falls_back_and_continues_suffix() {
     txs[0].gas_price = 50;
 
     let state = ParallelState::new(db, true, false);
-    let mut env = BlockEnv::default();
-    env.basefee = 100;
+    let env = BlockEnv { basefee: 100, ..Default::default() };
     let scheduler = Scheduler::new(
         CfgEnv::new_with_spec(SpecId::SHANGHAI),
         env,


### PR DESCRIPTION
## Summary

This PR adds two independent, opt-in safety policies for EIP-7702 delegated execution:

- **Forbid delegated `CREATE` / `CREATE2`**: reject contract creation only when the current execution context is an EIP-7702 delegated account. Ordinary `CREATE` and `CREATE2` remain unchanged.
- **Reserve delegated-account balance**: when delegated execution makes a surviving balance debit, prevent it from consuming funds conservatively required by later transactions from the same account.

Both policies default to `false`, so the existing Grevm/revm execution behavior is preserved unless they are explicitly enabled through `DelegatedSafetyConfig`.

## Reserve-balance semantics

For a delegated account `A` debited by transaction `Ti`:

```text
future_cost(A, i) =
    sum(tx.max_balance_spending())
    for later transactions whose caller is A

required_reserve =
    min(balance before A's first surviving delegated debit, future_cost(A, i))
```

The guard:

- checks only surviving delegated debits recorded by revm's journal;
- ignores reverted inner-frame transfers and the root transaction's ordinary `tx.value`;
- covers delegated `CALL` value transfers and post-Cancun `SELFDESTRUCT` balance movement;
- lazily builds a sender index and only computes a suffix schedule for accounts that actually make a delegated debit;
- uses the original block `TxId` in both parallel execution and sequential suffix fallback.

If the final balance is below the reserve, Grevm returns a top-level `REVERT`. Execution state, output, and execution-generated refunds are rolled back, while the transaction nonce, EIP-7702 authorization effects/refund, and gas charged for the attempted execution are preserved. Refund caps and the EIP-7623 gas floor are recomputed from the pre-refund gas state.

## Comparison with Monad

The Grevm policy follows Monad's core failure semantics but intentionally uses a narrower reserve model for Gravity Reth's skipped-invalid-transaction risk.

| Aspect | Grevm | Monad |
| --- | --- | --- |
| Reserve amount | `min(balance before the first surviving delegated debit, sum of later same-sender transactions' max balance spending)` | `min(original transaction balance, 10 MON)`, with a sender adjustment for upfront gas |
| Time horizon | Only transactions strictly after the current transaction in the same block | Does not sum later transaction costs; uses sender/authority history from the current, parent, and grandparent blocks to decide whether the sender may dip into reserve |
| Protected accounts | Only EIP-7702 accounts that make an actual surviving delegated-execution debit | Broader EOA and delegated-account tracking, with protocol-specific sender and account exemptions |
| Ordinary root `tx.value` | Explicitly excluded and left to transaction admission/filtering | May be reserve-protected when the transaction sender is delegated |
| Balance baseline | Balance immediately before the first surviving delegated debit, including credits received earlier in the same execution | Original balance at the start of the transaction |
| Check timing | Compares against the final balance after unused-gas reimbursement | Checks before unused gas is reimbursed; the sender threshold accounts for upfront gas |
| No later same-account transaction | Required reserve is zero, so the account may drain its balance | The account may still need to retain up to 10 MON |
| Later invalid transactions | Their `max_balance_spending()` is still included, so Grevm may conservatively over-reserve | Reserve size does not depend on later transaction costs |
| Value movement | Covers delegated calls and post-Cancun `SELFDESTRUCT`; reverted inner-frame debits are ignored | Covers balance mutations including calls and `SELFDESTRUCT`; rollback hooks remove reverted-frame violations |
| State on violation | Rolls back execution state while preserving the transaction nonce, EIP-7702 authorization effects, and charged gas | Same core state-preservation behavior |
| Refunds on violation | Discards execution-generated refunds, preserves the EIP-7702 authorization refund, and recomputes refund caps and the EIP-7623 floor | Discards execution-generated refunds and adds the EIP-7702 authorization refund back after execution |
| Result status | Standard top-level `REVERT`, preserving unused gas | Custom `EVMC_MONAD_RESERVE_BALANCE_VIOLATION`; top-level contract creation consequently has different remaining-gas behavior |
| Implementation | Post-execution scan of revm's surviving journal plus lazy deterministic per-account suffix schedules | Hooks balance debit, credit, rollback, and code changes directly in the state implementation |
| Activation | Opt-in `DelegatedSafetyConfig`; disabled by default | Protocol rule enabled from `MONAD_FOUR` |

Neither policy is uniformly stricter: Grevm requires no reserve when the account has no later transaction, but it can reserve more than 10 native tokens when the later maximum-spending sum is larger.

## Parallel correctness and determinism

- Reserve requirements depend only on the ordered block transaction list and the transaction's surviving journal entries.
- Lazy schedules are immutable after initialization and produce the same value regardless of which worker initializes them.
- Speculative balance reads continue to participate in Grevm's normal MV validation. A dedicated test forces a stale speculative read, verifies that the transaction is re-executed, and compares the complete parallel result and bundle state with forced-sequential execution.
- With reserve protection disabled, the handler retains revm's default validation, pre-execution, execution, and post-execution lifecycle.

## Refactoring

The PR also splits the previous monolithic scheduler/library implementation into focused modules:

- scheduler context, executor, fallback, metrics, and tests;
- runtime configuration;
- execution models and outcomes;
- bundle and cache-database helpers;
- isolated delegated-safety instructions, handler, and reserve planner.

This keeps the policy-specific logic out of the core scheduling path and makes parallel and sequential execution share the same configuration and transaction handler.

## Testing

- `cargo test --features test-utils` — all 70 tests passed.
- `cargo test --release --features test-utils --test delegated_safety` — all 13 delegated-safety tests passed.
- `cargo clippy --all-features --all-targets -- -D warnings` — passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `GREVM_MIN_PARALLEL_TXS=0 GREVM_MAINNET_BLOCKS=test_data/spec_coverage cargo test --features test-utils --test mainnet replay_mainnet_blocks -- --nocapture` — all 18 hardfork-boundary fixtures from Tangerine through Prague passed.
- The forced stale-read/re-execution test passed 100 consecutive runs.

CI now also builds every feature and target under Clippy with warnings denied.
